### PR TITLE
Fix indentation errors in navigation and events

### DIFF
--- a/events.py
+++ b/events.py
@@ -353,8 +353,8 @@ def event_ui(user: dict | None) -> None:
                 current_status = event.get('status', 'planning')
                 
                 if current_status == 'active':
-                     if st.button("Complete Event", key=f"complete_{event['id']}"):
-                         if complete_event_and_end_sessions(event["id"]):
+                    if st.button("Complete Event", key=f"complete_{event['id']}"):
+                        if complete_event_and_end_sessions(event["id"]):
                             st.success("✅ Event marked as complete.")
 
     if st.session_state.get("show_event_dashboard"):

--- a/layout.py
+++ b/layout.py
@@ -770,22 +770,23 @@ def _get_ai_response(message: str):
 def render_top_navbar(tabs):
     """Render clean purple-themed navigation tabs using Streamlit native components"""
     if not tabs:
-
-    # Inject logo banner above tabs
-    st.markdown("""
-    <div style="text-align:center; padding: 1rem 0;">
-      <img src="/mountain_logo_banner.png" style="max-width: 600px; height: auto;" alt="Mountain Medicine">
-    </div>
-    """, unsafe_allow_html=True)
-
         st.warning("⚠️ No navigation tabs defined.")
         return
+
+    # Inject logo banner above tabs
+    st.markdown(
+        """
+        <div style="text-align:center; padding: 1rem 0;">
+            <img src="/mountain_logo_banner.png" style="max-width: 600px; height: auto;" alt="Mountain Medicine">
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
     default_tab = "Dashboard" if "Dashboard" in tabs else tabs[0]
     current_tab = st.session_state.get("top_nav", default_tab)
 
     if current_tab not in tabs:
-        current_tab = tabs[0] if tabs else "Dashboard"
         current_tab = default_tab
         st.session_state["top_nav"] = current_tab
 
@@ -897,7 +898,7 @@ def render_status_indicator(status):
 def apply_theme():
     """Apply the complete Mountain Medicine theme"""
     import time
-    st.session_state["current_location"] = f"main_header_{int(time.time()}"
+    st.session_state["current_location"] = f"main_header_{int(time.time())}"
     
     inject_custom_css()
     render_event_mode_indicator()


### PR DESCRIPTION
## Summary
- repair indentation in `render_top_navbar`
- close f-string in `apply_theme`
- align nested blocks in `event_ui`

## Testing
- `python -m py_compile events.py layout.py app.py upload.py`

------
https://chatgpt.com/codex/tasks/task_e_6850dee3fb688326b14ee5902e0e07be