### PR TITLE
Fix startup error with recipes import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Thumbs.db
 
 # Other
 *.bak
+# Temporary pip logs
+=*

--- a/ai_chat.py
+++ b/ai_chat.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from datetime import datetime
 from auth import get_user_role
-from db_client import db
+from firebase_init import db
 from utils import format_date, generate_id, get_active_event, get_active_event_id
 import json
 from google.cloud.firestore_v1.base_query import FieldFilter

--- a/recipes.py
+++ b/recipes.py
@@ -118,3 +118,36 @@ def save_ingredient_to_firestore(ingredient_data, user_id=None, file_id=None):
     }
     db.collection("ingredients").document(ing_id).set(doc)
     return ing_id
+
+
+# ----------------------------
+# 📖 Recipes Tab (Public)
+# ----------------------------
+
+def recipes_page():
+    """Simple recipe browsing page."""
+    st.title("📚 Recipes")
+
+    try:
+        recipes = [
+            doc.to_dict() | {"id": doc.id}
+            for doc in db.collection("recipes")
+            .order_by("created_at", direction=firestore.Query.DESCENDING)
+            .stream()
+        ]
+    except Exception as e:
+        st.error(f"Failed to load recipes: {e}")
+        return
+
+    if not recipes:
+        st.info("No recipes found.")
+        return
+
+    for recipe in recipes:
+        with st.expander(recipe.get("name", "Unnamed Recipe")):
+            st.markdown(
+                f"**Created:** {format_date(recipe.get('created_at'))}"
+            )
+            instructions = recipe.get("instructions") or "—"
+            st.markdown(instructions)
+            st.markdown("---")

--- a/user_admin.py
+++ b/user_admin.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from utils import format_timestamp
 from notifications import send_notification
 from auth import require_role, sync_firebase_users, delete_firebase_user
-from db_client import db  # ✅ Fixed: Use centralized database client
+from firebase_init import db  # ✅ Fixed: Use centralized database client
 from google.cloud.firestore_v1.base_query import FieldFilter
 
 # ----------------------------


### PR DESCRIPTION
## Summary
- ignore pip log files
- restore a basic `recipes_page` implementation to satisfy app imports

## Testing
- `python -m py_compile ai_chat.py user_admin.py recipes.py`
- `python - <<'PY'
import app
print('app imported')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6850f8cf7bb083268490f3f2feaf24ce