### PR TITLE
Fix token redirect loop causing blank screen

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,7 +105,9 @@ def handle_auth_routing():
     import streamlit.components.v1 as components
     query_params = st.experimental_get_query_params()
 
-    if "token" not in query_params:
+    user_logged_in = "user" in st.session_state
+
+    if "token" not in query_params and not user_logged_in:
         components.html('''
         <script>
         const token = localStorage.getItem("mm_token") || "";


### PR DESCRIPTION
## Summary
- fix auth routing to stop redirecting when user is already logged in

## Testing
- `python -m py_compile app.py`
- `python -m py_compile auth.py`


------
https://chatgpt.com/codex/tasks/task_e_6850fccef3c883269f5bb536aa4a9508