### PR TITLE
Enable shopping list metadata and parsed data editing

### DIFF
--- a/mobile_components.py
+++ b/mobile_components.py
@@ -275,15 +275,30 @@ def mobile_select(
     for option in options:
         selected = 'selected' if option == value else ''
         select_html += f'<option value="{option}" {selected}>{option}</option>'
-    
+
     select_html += """
             </select>
         </div>
     </div>
     """
-    
-    st.markdown(select_html, unsafe_allow_html=True)
-    
+
+    select_js = f"""
+    <script>
+    const sel_{select_id} = document.getElementById('{select_id}');
+    if (sel_{select_id}) {{
+        sel_{select_id}.addEventListener('change', (e) => {{
+            window.parent.postMessage({{
+                type: 'streamlit:setComponentValue',
+                key: '{select_id}',
+                value: e.target.value
+            }}, '*');
+        }});
+    }}
+    </script>
+    """
+
+    st.markdown(select_html + select_js, unsafe_allow_html=True)
+
     return st.session_state.get(select_id, value or options[0] if options else "")
 
 def mobile_button(

--- a/shopping_lists.py
+++ b/shopping_lists.py
@@ -1,0 +1,63 @@
+import streamlit as st
+from firebase_init import get_db
+from datetime import datetime
+from utils import generate_id
+
+db = get_db()
+
+# ----------------------------
+# 🛒 Shopping List Management
+# ----------------------------
+
+def create_shopping_list(list_data: dict, user_id: str | None = None) -> str | None:
+    """Create a shopping list document"""
+    try:
+        list_id = generate_id("shoplist")
+        doc = {
+            "id": list_id,
+            "name": list_data.get("name", "Untitled Shopping List"),
+            "items": list_data.get("items", []),
+            "tags": list_data.get("tags", []),
+            "created_by": user_id,
+            "created_at": datetime.utcnow(),
+            "deleted": False,
+            "source_file": list_data.get("source_file"),
+            "parsed_data": list_data.get("parsed_data", {}),
+        }
+        db.collection("shopping_lists").document(list_id).set(doc)
+        return list_id
+    except Exception as e:
+        st.error(f"❌ Failed to create shopping list: {e}")
+        return None
+
+def update_shopping_list(list_id: str, updates: dict) -> bool:
+    """Update an existing shopping list"""
+    try:
+        updates["updated_at"] = datetime.utcnow()
+        db.collection("shopping_lists").document(list_id).update(updates)
+        return True
+    except Exception as e:
+        st.error(f"❌ Failed to update shopping list: {e}")
+        return False
+
+def delete_shopping_list(list_id: str) -> bool:
+    """Soft delete a shopping list"""
+    try:
+        db.collection("shopping_lists").document(list_id).update({
+            "deleted": True,
+            "deleted_at": datetime.utcnow(),
+        })
+        return True
+    except Exception as e:
+        st.error(f"❌ Failed to delete shopping list: {e}")
+        return False
+
+def get_shopping_list(list_id: str) -> dict | None:
+    """Fetch a single shopping list"""
+    doc = db.collection("shopping_lists").document(list_id).get()
+    return doc.to_dict() if doc.exists else None
+
+def list_shopping_lists() -> list:
+    """List all shopping lists"""
+    docs = db.collection("shopping_lists").where("deleted", "==", False).stream()
+    return [d.to_dict() | {"id": d.id} for d in docs]

--- a/upload.py
+++ b/upload.py
@@ -4,6 +4,7 @@ from utils import session_get, format_date, get_active_event_id
 from file_storage import save_uploaded_file, file_manager_ui
 from upload_integration import save_parsed_menu_ui, show_save_file_actions
 from ui_components import render_tag_group, edit_metadata_ui
+from firebase_init import get_db
 from events import get_all_events
 from mobile_helpers import safe_file_uploader
 from recipes import save_recipe_to_firestore
@@ -89,6 +90,7 @@ def upload_ui_mobile():
     st.title("📤 Upload Files")
     user_id = get_user_id()
     event_id = get_active_event_id()
+    db = get_db()
 
     st.markdown("### Upload a new file")
     uploaded_file = st.file_uploader("Drop or select a file", type=["pdf", "txt", "jpg", "png", "jpeg", "csv", "docx"])
@@ -100,12 +102,13 @@ def upload_ui_mobile():
 
         st.success("✅ File uploaded and parsed.")
 
-        if st.button("View / Edit Parsed Data"):
-            parsed = result.get("parsed", {})
-            parsed = edit_metadata_ui(parsed)
-            render_tag_group("Recipe", [parsed.get("title", "")], color="green")
-            render_tag_group("Allergens", parsed.get("allergens", []), color="red")
-            render_tag_group("Tags", parsed.get("tags", []), color="purple")
+        if st.button("View / Edit Data"):
+            from file_storage import _render_parsed_data_editor
+            _render_parsed_data_editor({
+                "id": result["file_id"],
+                "name": uploaded_file.name,
+                "parsed_data": {"parsed": result.get("parsed", {})}
+            }, db)
 
         show_save_file_actions(st.session_state["last_uploaded_file"])
 

--- a/upload_integration.py
+++ b/upload_integration.py
@@ -2,6 +2,7 @@ import streamlit as st
 from firebase_init import db
 from utils import get_active_event_id
 from auth import get_user_id
+from shopping_lists import create_shopping_list
 from datetime import datetime
 from recipes import save_menu_to_firestore
 
@@ -58,7 +59,7 @@ def show_save_file_actions(upload_info: dict):
     uploaded_name = parsed.get("title") or parsed.get("name") or "Unnamed File"
 
     st.markdown("### 💾 Save File As...")
-    col1, col2 = st.columns(2)
+    col1, col2, col3 = st.columns(3)
 
     with col1:
         if st.button("🍲 Save as Recipe", key=f"save_as_recipe_{file_id}"):
@@ -82,8 +83,6 @@ def show_save_file_actions(upload_info: dict):
             db.collection("events").document().set(event_doc)
             st.success("✅ File saved as Event")
 
-    col3, col4 = st.columns(2)
-
     with col3:
         if st.button("📖 Save as Menu", key=f"save_as_menu_{file_id}"):
             db.collection("menus").document().set({
@@ -94,6 +93,8 @@ def show_save_file_actions(upload_info: dict):
             })
             st.success("✅ File saved as Menu")
 
+    col4, col5 = st.columns(2)
+
     with col4:
         if st.button("🥬 Save as Ingredient", key=f"save_as_ingredient_{file_id}"):
             db.collection("ingredients").document().set({
@@ -103,3 +104,13 @@ def show_save_file_actions(upload_info: dict):
                 "parsed_data": parsed,
             })
             st.success("✅ File saved as Ingredient")
+
+    with col5:
+        if st.button("🛒 Save as Shopping List", key=f"save_as_shoplist_{file_id}"):
+            create_shopping_list({
+                "name": uploaded_name,
+                "source_file": file_id,
+                "parsed_data": parsed,
+                "items": parsed.get("items", []),
+            }, user_id=get_user_id())
+            st.success("✅ File saved as Shopping List")


### PR DESCRIPTION
## Summary
- add a dedicated `shopping_lists` structure
- enhance file manager with view/edit JSON data and new save-as options
- support saving uploads as a shopping list
- allow editing parsed data in upload flow
- fix mobile dropdowns so selection persists

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68510455a0d08326add715ec97eb0bf2