### PR TITLE
Fix form key conflicts and tab style

### DIFF
--- a/events.py
+++ b/events.py
@@ -309,7 +309,7 @@ def event_ui(user: dict | None) -> None:
             if event.get('description'):
                 st.markdown(f"**Description:** {event.get('description')}")
                 
-            menu_viewer_ui(event["id"])
+            menu_viewer_ui(event["id"], key_prefix=f"{event['id']}_")
             
             with col1:
                 st.markdown(f"**Location:** {event.get('location', 'Unknown')}")

--- a/menu_editor.py
+++ b/menu_editor.py
@@ -8,7 +8,8 @@ from datetime import datetime
 # 🍽️ Full Menu Editor UI
 # ----------------------------
 
-def full_menu_editor_ui(event_id=None):
+def full_menu_editor_ui(event_id=None, key_prefix: str = ""):
+    """Full menu editor UI with scoped widget keys."""
     st.title("🍽️ Event Menu Editor")
 
     # Shortcut to historical menu viewer
@@ -42,14 +43,45 @@ def full_menu_editor_ui(event_id=None):
     updated_menu = []
     for i, item in enumerate(menu):
         bg_color = meal_colors.get(item.get("meal", "note").lower(), "#f0f0f0")
-        with st.expander(f"{item.get('day', 'Day')} - {item.get('meal', 'Meal')}", expanded=False):
-            st.markdown(f"<div style='background-color:{bg_color};padding:1em;border-radius:8px;'>", unsafe_allow_html=True)
-            day = st.text_input(f"Day #{i+1}", value=item.get("day", ""), key=f"day_{i}")
-            meal = st.selectbox(f"Meal #{i+1}", ["Breakfast", "Lunch", "Dinner", "Note"], index=_get_meal_index(item.get("meal")), key=f"meal_{i}")
-            recipe = st.text_input(f"Recipe Name #{i+1}", value=item.get("recipe", ""), key=f"recipe_{i}")
-            notes = st.text_area(f"Notes #{i+1}", value=item.get("notes", ""), key=f"notes_{i}")
-            allergens = st.text_input(f"Allergens #{i+1}", value=", ".join(item.get("allergens", [])), key=f"allergens_{i}")
-            tags = st.text_input(f"Tags #{i+1}", value=", ".join(item.get("tags", [])), key=f"tags_{i}")
+        with st.expander(
+            f"{item.get('day', 'Day')} - {item.get('meal', 'Meal')}",
+            expanded=False,
+        ):
+            st.markdown(
+                f"<div style='background-color:{bg_color};padding:1em;border-radius:8px;'>",
+                unsafe_allow_html=True,
+            )
+            day = st.text_input(
+                f"Day #{i+1}",
+                value=item.get("day", ""),
+                key=f"{key_prefix}day_{i}"
+            )
+            meal = st.selectbox(
+                f"Meal #{i+1}",
+                ["Breakfast", "Lunch", "Dinner", "Note"],
+                index=_get_meal_index(item.get("meal")),
+                key=f"{key_prefix}meal_{i}"
+            )
+            recipe = st.text_input(
+                f"Recipe Name #{i+1}",
+                value=item.get("recipe", ""),
+                key=f"{key_prefix}recipe_{i}"
+            )
+            notes = st.text_area(
+                f"Notes #{i+1}",
+                value=item.get("notes", ""),
+                key=f"{key_prefix}notes_{i}"
+            )
+            allergens = st.text_input(
+                f"Allergens #{i+1}",
+                value=", ".join(item.get("allergens", [])),
+                key=f"{key_prefix}allergens_{i}"
+            )
+            tags = st.text_input(
+                f"Tags #{i+1}",
+                value=", ".join(item.get("tags", [])),
+                key=f"{key_prefix}tags_{i}"
+            )
             st.markdown("</div>", unsafe_allow_html=True)
 
             updated_menu.append({
@@ -62,16 +94,21 @@ def full_menu_editor_ui(event_id=None):
             })
 
     st.markdown("### ➕ Add New Menu Item")
-    with st.form("new_menu_item_form", clear_on_submit=True):
+    form_key = f"{key_prefix}new_menu_item_form"
+    with st.form(form_key, clear_on_submit=True):
         col1, col2 = st.columns(2)
         with col1:
-            new_day = st.text_input("Day")
-            new_meal = st.selectbox("Meal", ["Breakfast", "Lunch", "Dinner", "Note"])
-            new_recipe = st.text_input("Recipe Name")
+            new_day = st.text_input("Day", key=f"{key_prefix}new_day")
+            new_meal = st.selectbox(
+                "Meal",
+                ["Breakfast", "Lunch", "Dinner", "Note"],
+                key=f"{key_prefix}new_meal"
+            )
+            new_recipe = st.text_input("Recipe Name", key=f"{key_prefix}new_recipe")
         with col2:
-            new_notes = st.text_area("Notes")
-            new_allergens = st.text_input("Allergens (comma-separated)")
-            new_tags = st.text_input("Tags (comma-separated)")
+            new_notes = st.text_area("Notes", key=f"{key_prefix}new_notes")
+            new_allergens = st.text_input("Allergens (comma-separated)", key=f"{key_prefix}new_allergens")
+            new_tags = st.text_input("Tags (comma-separated)", key=f"{key_prefix}new_tags")
 
         submit_new = st.form_submit_button("Add Menu Item")
         if submit_new:

--- a/menu_viewer.py
+++ b/menu_viewer.py
@@ -11,7 +11,8 @@ from recipes import save_menu_to_firestore
 # ----------------------------
 
 @require_role("user")
-def menu_viewer_ui(event_id=None):
+def menu_viewer_ui(event_id=None, key_prefix: str = ""):
+    """Display and edit an event menu with scoped widget keys."""
     st.title("🍽️ Event Menu")
 
     if not event_id:
@@ -33,18 +34,26 @@ def menu_viewer_ui(event_id=None):
     updated_menu = []
     for i, item in enumerate(menu):
         with st.expander(f"{item.get('name', 'Untitled Dish')}", expanded=False):
-            name = st.text_input(f"Dish Name #{i+1}", item.get("name", ""), key=f"name_{i}")
+            name = st.text_input(
+                f"Dish Name #{i+1}",
+                item.get("name", ""),
+                key=f"{key_prefix}name_{i}"
+            )
             category = st.selectbox(
                 f"Category #{i+1}",
                 ["Appetizer", "Main", "Side", "Dessert", "Drink", "Other"],
                 index=_get_category_index(item.get("category")),
-                key=f"cat_{i}"
+                key=f"{key_prefix}cat_{i}"
             )
             description = st.text_area(
-                f"Description #{i+1}", item.get("description", ""), key=f"desc_{i}"
+                f"Description #{i+1}",
+                item.get("description", ""),
+                key=f"{key_prefix}desc_{i}"
             )
             tags = st.text_input(
-                f"Tags #{i+1} (comma-separated)", ", ".join(item.get("tags", [])), key=f"tags_{i}"
+                f"Tags #{i+1} (comma-separated)",
+                ", ".join(item.get("tags", [])),
+                key=f"{key_prefix}tags_{i}"
             )
             updated_menu.append({
                 "name": name.strip(),
@@ -54,15 +63,16 @@ def menu_viewer_ui(event_id=None):
             })
 
     st.markdown("### ➕ Add New Menu Item")
-    with st.form("new_menu_item_form", clear_on_submit=True):
-        new_name = st.text_input("New Dish Name")
+    form_key = f"{key_prefix}new_menu_item_form"
+    with st.form(form_key, clear_on_submit=True):
+        new_name = st.text_input("New Dish Name", key=f"{key_prefix}new_name")
         new_category = st.selectbox(
             "New Category",
             ["Appetizer", "Main", "Side", "Dessert", "Drink", "Other"],
-            key="new_category",
+            key=f"{key_prefix}new_category",
         )
-        new_description = st.text_area("New Description")
-        new_tags = st.text_input("New Tags (comma-separated)")
+        new_description = st.text_area("New Description", key=f"{key_prefix}new_desc")
+        new_tags = st.text_input("New Tags (comma-separated)", key=f"{key_prefix}new_tags")
         submitted = st.form_submit_button("Add Menu Item")
         if submitted and new_name.strip():
             updated_menu.append({

--- a/style.css
+++ b/style.css
@@ -438,3 +438,23 @@ button:active, .stButton > button:active {
 .loading {
     animation: pulse 1.5s ease-in-out infinite !important;
 }
+
+/* -----------------------------
+   Tab Styling Overrides
+----------------------------- */
+.stTabs [data-baseweb="tab"] button {
+    background: var(--primary-purple) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+    border-radius: var(--border-radius) var(--border-radius) 0 0 !important;
+    padding: 0.5rem 1rem !important;
+    margin-right: 0.25rem !important;
+}
+
+.stTabs [data-baseweb="tab"][aria-selected="true"] button {
+    background: var(--dark-purple) !important;
+    color: #fff !important;
+}
+
+.stTabs [data-baseweb="tab-highlight"] {
+    display: none !important;
+}


### PR DESCRIPTION
## Summary
- provide a `key_prefix` option for `menu_viewer_ui` and `full_menu_editor_ui`
- use that option in `events.py` to keep menu forms unique
- hide duplicate menu forms by scoping widget keys
- style Streamlit tabs so the entire tab changes color when selected and remove the default indicator

## Testing
- `python -m py_compile events.py menu_viewer.py menu_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_685105a9548483268c3b42acb21e2eaf