### PR TITLE
Improve mobile detection and navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,12 @@ import streamlit.components.v1 as components
 components.html("""
 <script>
   const token = localStorage.getItem('mm_token') || "";
-  const device = localStorage.getItem('mm_device') || "desktop";
+  let device = localStorage.getItem('mm_device');
+  if (!device) {
+    const ua = navigator.userAgent.toLowerCase();
+    device = /iphone|ipad|android/.test(ua) ? "mobile" : "desktop";
+    localStorage.setItem('mm_device', device);
+  }
   const query = `?token=${token}&device=${device}`;
   if (!window.location.search.includes("token=") && token) {
     window.location.href = window.location.pathname + query;

--- a/layout.py
+++ b/layout.py
@@ -895,12 +895,15 @@ def responsive_container():
         
         /* Mobile navigation */
         .nav-tabs {
-            flex-direction: column !important;
+            flex-direction: row !important;
+            flex-wrap: nowrap !important;
+            overflow-x: auto !important;
+            -webkit-overflow-scrolling: touch !important;
             gap: 0.5rem !important;
         }
-        
+
         .nav-tab {
-            width: 100% !important;
+            flex: 0 0 auto !important;
         }
         
         /* Mobile event indicator */


### PR DESCRIPTION
## Summary
- detect device type in `app.py` if not stored in localStorage
- improve mobile navigation CSS to keep tabs horizontal and scrollable

## Testing
- `python -m py_compile app.py layout.py mobile_helpers.py mobile_layout.py`

------
https://chatgpt.com/codex/tasks/task_e_68517323b19883268aa3674e31bd141d