### PR TITLE
Add recipe link parser and mobile UI fixes

### DIFF
--- a/ai_parsing_engine.py
+++ b/ai_parsing_engine.py
@@ -6,6 +6,8 @@ import openai
 import fitz  # PyMuPDF
 from PIL import Image
 import pytesseract
+import requests
+from bs4 import BeautifulSoup
 import json
 from datetime import datetime
 import streamlit as st
@@ -144,6 +146,26 @@ def query_ai_parser(raw_text, target_type):
     except Exception as e:
         st.error(f"OpenAI error: {e}")
         return {}
+
+# --------------------------------------------
+# 🌐 Parse Recipe From URL
+# --------------------------------------------
+
+def parse_recipe_from_url(url: str) -> dict:
+    """Fetch a recipe webpage and extract structured data."""
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        text = soup.get_text(separator="\n")
+    except Exception as e:
+        st.error(f"Failed to fetch page: {e}")
+        return {}
+
+    parsed = query_ai_parser(text, "recipes")
+    if isinstance(parsed, list):
+        return parsed[0] if parsed else {}
+    return parsed or {}
 
 # --------------------------------------------
 # 💾 Modular Save Buttons

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,13 +1,14 @@
 import streamlit as st
 from event_mode import get_event_context
 from utils import format_date
-from mobile_layout import mobile_card, render_mobile_navigation
+from mobile_layout import mobile_card, mobile_layout
 
 def render_dashboard(user=None):
     st.title("📊 Dashboard")
 
     if st.session_state.get("mobile_mode"):
-        render_mobile_navigation()
+        mobile_layout.render_mobile_dashboard(user, get_event_context())
+        return
 
     event = get_event_context()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ python-dateutil>=2.8.0
 pytesseract>=0.3.10
 PyMuPDF>=1.22.0
 pdf2image>=1.16.3
+beautifulsoup4>=4.13.0


### PR DESCRIPTION
## Summary
- allow parsing recipes from webpage URLs via `parse_recipe_from_url`
- add `beautifulsoup4` to requirements
- implement `add_recipe_via_link_ui` and mobile/desktop recipe cards
- use mobile dashboard rendering when on mobile
- fix circular import in recipe link parsing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851885175188326b8f7419c47a19033