### PR TITLE
Implement offline parsing fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 
 
 Instructions and structure overview.
+
+## Offline Parsing
+The app normally uses OpenAI to extract recipes, menus and other data. If the
+API cannot be reached, a fallback parser uses simple regex heuristics. This
+offline mode supports basic extraction of ingredients, instructions, menus and
+common allergens.


### PR DESCRIPTION
## Summary
- add `offline_parse` utility for basic regex-based extraction
- fall back to offline parser when OpenAI errors occur
- document offline parsing behavior in README

## Testing
- `python -m py_compile ai_parsing_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6851970162108326a539fe32b9d54466