### PR TITLE
Fix OpenAI parsing error and improve mobile redirect

### DIFF
--- a/ai_parsing_engine.py
+++ b/ai_parsing_engine.py
@@ -155,7 +155,7 @@ def query_ai_parser(raw_text, target_type):
 
     try:
         response = client.chat.completions.create(
-            model="gpt-4",
+            model="gpt-4o-mini",
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}

--- a/app.py
+++ b/app.py
@@ -27,8 +27,10 @@ components.html("""
     device = /iphone|ipad|android/.test(ua) ? "mobile" : "desktop";
     localStorage.setItem('mm_device', device);
   }
+  const handled = localStorage.getItem('mm_token_handled') === 'true';
   const query = `?token=${token}&device=${device}`;
-  if (!window.location.search.includes("token=") && token) {
+  if (!window.location.search.includes("token=") && token && !handled) {
+    localStorage.setItem('mm_token_handled', 'true');
     window.location.href = window.location.pathname + query;
   }
 </script>


### PR DESCRIPTION
## Summary
- use `gpt-4o-mini` for JSON-format parsing to avoid invalid parameter errors
- prevent infinite redirects by checking `mm_token_handled`

## Testing
- `python -m compileall -q ai_parsing_engine.py app.py`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6851ade9aa588326adc18a58c683ef3d