### PR TITLE
Inline editors for parsed uploads

### DIFF
--- a/ingredients_editor.py
+++ b/ingredients_editor.py
@@ -1,0 +1,59 @@
+import streamlit as st
+from firebase_init import db
+from auth import get_user_id
+from datetime import datetime
+from utils import generate_id
+
+
+def ingredients_editor_ui(ingredient_id=None, prefill_data=None):
+    """Edit or create an ingredient."""
+    st.title("🥕 Ingredient Editor")
+
+    user_id = get_user_id()
+    doc_ref = None
+    ingredient = None
+
+    if ingredient_id:
+        doc_ref = db.collection("ingredients").document(ingredient_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            st.error("Ingredient not found.")
+            return
+        ingredient = doc.to_dict()
+    elif prefill_data:
+        ingredient = prefill_data
+        st.info("💡 This form is pre-filled from parsed data.")
+    else:
+        st.warning("No ingredient to show.")
+        return
+
+    with st.form("edit_ingredient_form"):
+        name = st.text_input("Ingredient Name", value=ingredient.get("name", ""))
+        unit = st.text_input("Unit", value=ingredient.get("unit", ""))
+        category = st.text_input("Category", value=ingredient.get("category", ""))
+        notes = st.text_area("Notes", value=ingredient.get("notes", ""))
+        tags = st.text_input(
+            "Tags (comma-separated)",
+            value=", ".join(ingredient.get("tags", []))
+        )
+
+        submitted = st.form_submit_button("💾 Save")
+        if submitted:
+            data = {
+                "name": name,
+                "unit": unit,
+                "category": category,
+                "notes": notes,
+                "tags": [t.strip() for t in tags.split(",") if t.strip()],
+                "updated_at": datetime.utcnow(),
+                "updated_by": user_id,
+            }
+            if doc_ref:
+                doc_ref.update(data)
+                st.success("✅ Ingredient updated!")
+            else:
+                ing_id = generate_id("ing")
+                data["created_at"] = datetime.utcnow()
+                data["created_by"] = user_id
+                db.collection("ingredients").document(ing_id).set(data)
+                st.success("✅ Ingredient saved!")

--- a/recipes_editor.py
+++ b/recipes_editor.py
@@ -6,28 +6,33 @@ from utils import get_active_event_id, generate_id
 from auth import get_user_id
 from ingredients import parse_recipe_ingredients, update_recipe_with_parsed_ingredients
 from allergies import render_allergy_warning
+from recipes import save_recipe_to_firestore
 
 # ----------------------------
 # 📖 Recipe Editor UI
 # ----------------------------
 
-def recipe_editor_ui(recipe_id=None):
+def recipe_editor_ui(recipe_id=None, prefill_data=None):
     st.title("📖 Recipe Editor")
 
     user_id = get_user_id()
     event_id = get_active_event_id()
 
-    if not recipe_id:
-        st.warning("No recipe selected.")
+    doc_ref = None
+    recipe = None
+    if recipe_id:
+        doc_ref = db.collection("recipes").document(recipe_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            st.error("Recipe not found.")
+            return
+        recipe = doc.to_dict()
+    elif prefill_data:
+        recipe = prefill_data
+        st.info("💡 This form is pre-filled from parsed data.")
+    else:
+        st.warning("No recipe to show.")
         return
-
-    doc_ref = db.collection("recipes").document(recipe_id)
-    doc = doc_ref.get()
-    if not doc.exists:
-        st.error("Recipe not found.")
-        return
-
-    recipe = doc.to_dict()
 
     if recipe.get("image_url"):
         st.image(recipe["image_url"], use_column_width=True, caption="📷 Recipe Image")
@@ -69,7 +74,7 @@ def recipe_editor_ui(recipe_id=None):
         new_variant_instructions = st.text_area("Modified Instructions", key="new_variant_instructions")
 
         add_variant = st.form_submit_button("Add Variant")
-        if add_variant and new_variant_label:
+        if add_variant and new_variant_label and doc_ref:
             variant = {
                 "label": new_variant_label,
                 "notes": new_variant_notes,
@@ -92,34 +97,47 @@ def recipe_editor_ui(recipe_id=None):
                 "timestamp": datetime.utcnow(),
                 "edited_by": user_id
             }
-            doc_ref.collection("versions").document(generate_id("ver")).set(version_entry)
+            if doc_ref:
+                doc_ref.collection("versions").document(generate_id("ver")).set(version_entry)
+                doc_ref.update({
+                    "name": name,
+                    "ingredients": ingredients,
+                    "instructions": instructions,
+                    "notes": notes,
+                    "tags": version_entry["tags"],
+                    "updated_at": datetime.utcnow(),
+                    "updated_by": user_id
+                })
+                update_recipe_with_parsed_ingredients(recipe_id, ingredients)
+                st.success("✅ Recipe updated!")
+            else:
+                # New recipe from parsed data
+                new_id = save_recipe_to_firestore({
+                    "title": name,
+                    "ingredients": ingredients,
+                    "instructions": instructions,
+                    "notes": notes,
+                    "tags": version_entry["tags"]
+                }, user_id=user_id)
+                if new_id:
+                    st.success("✅ Recipe saved!")
 
-            doc_ref.update({
-                "name": name,
-                "ingredients": ingredients,
-                "instructions": instructions,
-                "notes": notes,
-                "tags": version_entry["tags"],
-                "updated_at": datetime.utcnow(),
-                "updated_by": user_id
-            })
-
-            update_recipe_with_parsed_ingredients(recipe_id, ingredients)
-            st.success("✅ Recipe updated!")
-
-    st.markdown("---")
-    st.markdown("### 🕓 Version History")
-    versions = doc_ref.collection("versions").order_by("timestamp", direction=firestore.Query.DESCENDING).stream()
-    for v in versions:
-        vdata = v.to_dict()
-        timestamp = vdata.get("timestamp")
-        label = timestamp.strftime("%Y-%m-%d %H:%M") if timestamp else "Unknown"
-        with st.expander(f"🕓 {label} - {vdata.get('edited_by')}"):
-            st.write("**Name:**", vdata.get("name"))
-            st.write("**Instructions:**")
-            st.code(vdata.get("instructions", ""))
-            st.write("**Notes:**", vdata.get("notes", ""))
-            if vdata.get("edit_note"):
-                st.info(f"📝 Edit Note: {vdata.get('edit_note')}")
-            st.caption(f"Tags: {', '.join(vdata.get('tags', []))}")
+    if doc_ref:
+        st.markdown("---")
+        st.markdown("### 🕓 Version History")
+        versions = doc_ref.collection("versions").order_by(
+            "timestamp", direction=firestore.Query.DESCENDING
+        ).stream()
+        for v in versions:
+            vdata = v.to_dict()
+            timestamp = vdata.get("timestamp")
+            label = timestamp.strftime("%Y-%m-%d %H:%M") if timestamp else "Unknown"
+            with st.expander(f"🕓 {label} - {vdata.get('edited_by')}"):
+                st.write("**Name:**", vdata.get("name"))
+                st.write("**Instructions:")
+                st.code(vdata.get("instructions", ""))
+                st.write("**Notes:**", vdata.get("notes", ""))
+                if vdata.get("edit_note"):
+                    st.info(f"📝 Edit Note: {vdata.get('edit_note')}")
+                st.caption(f"Tags: {', '.join(vdata.get('tags', []))}")
 


### PR DESCRIPTION
## Summary
- support prefilling recipe and menu editors with parsed data
- add new ingredient editor with similar prefill capability
- detect parsed content type in file manager and render the matching editor inline

## Testing
- `python -m py_compile file_storage.py recipes_editor.py menu_editor.py ingredients_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_6852038906cc8326bd2defba1ea550f2