### PR TITLE
Fix recipe parsing prefill

### DIFF
--- a/recipe_viewer.py
+++ b/recipe_viewer.py
@@ -21,7 +21,7 @@ def render_recipe_preview(parsed_data):
 
     st.subheader("🧪 Auto-Detected Recipe Preview")
 
-    st.text_input("Recipe Name", value=recipe.get("name", ""))
+    st.text_input("Recipe Name", value=recipe.get("name") or recipe.get("title", ""))
 
     ingredients = recipe.get("ingredients", [])
     pretty_ingredients = []

--- a/recipes.py
+++ b/recipes.py
@@ -68,7 +68,7 @@ def save_recipe_to_firestore(recipe_data, user_id=None, file_id=None):
     recipe_id = str(uuid.uuid4())
     doc = {
         "id": recipe_id,
-        "name": recipe_data.get("title", "Untitled"),
+        "name": recipe_data.get("title") or recipe_data.get("name", "Untitled"),
         "ingredients": recipe_data.get("ingredients", []),
         "instructions": recipe_data.get("instructions", []),
         "tags": recipe_data.get("tags", []),

--- a/recipes_editor.py
+++ b/recipes_editor.py
@@ -37,10 +37,14 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
     if recipe.get("image_url"):
         st.image(recipe["image_url"], use_column_width=True, caption="📷 Recipe Image")
 
-    st.subheader(f"Editing: {recipe.get('name', 'Unnamed Recipe')}")
+    display_name = recipe.get("name") or recipe.get("title", "Unnamed Recipe")
+    st.subheader(f"Editing: {display_name}")
 
     with st.form("edit_recipe_form"):
-        name = st.text_input("Recipe Name", value=recipe.get("name", ""))
+        name = st.text_input(
+            "Recipe Name",
+            value=recipe.get("name") or recipe.get("title", ""),
+        )
         ingredients = st.text_area("Ingredients", value=recipe.get("ingredients", ""))
         instructions = st.text_area("Instructions", value=recipe.get("instructions", ""))
         notes = st.text_area("Notes", value=recipe.get("notes", ""))
@@ -112,13 +116,16 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
                 st.success("✅ Recipe updated!")
             else:
                 # New recipe from parsed data
-                new_id = save_recipe_to_firestore({
-                    "title": name,
-                    "ingredients": ingredients,
-                    "instructions": instructions,
-                    "notes": notes,
-                    "tags": version_entry["tags"]
-                }, user_id=user_id)
+                new_id = save_recipe_to_firestore(
+                    {
+                        "name": name,
+                        "ingredients": ingredients,
+                        "instructions": instructions,
+                        "notes": notes,
+                        "tags": version_entry["tags"],
+                    },
+                    user_id=user_id,
+                )
                 if new_id:
                     st.success("✅ Recipe saved!")
 

--- a/upload.py
+++ b/upload.py
@@ -48,7 +48,10 @@ def upload_ui_desktop(event_id: str = None):
 
             st.markdown("### 🧪 Auto-Detected Recipe Preview")
             with st.form("confirm_recipe_from_upload"):
-                name = st.text_input("Recipe Name", recipe_draft.get("name", ""))
+                name = st.text_input(
+                    "Recipe Name",
+                    recipe_draft.get("name") or recipe_draft.get("title", ""),
+                )
                 ingredients = st.text_area("Ingredients", recipe_draft.get("ingredients", ""))
                 instructions = st.text_area("Instructions", recipe_draft.get("instructions", ""))
                 notes = st.text_area("Notes", recipe_draft.get("notes", ""))


### PR DESCRIPTION
## Summary
- handle `title` or `name` keys for parsed recipes
- update editor save logic
- handle title fallback when previewing recipes
- allow upload recipe form to use either key

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_6852533cdb9883268f76582ed8d642a2