### PR TITLE
Fix recipe parsing prefill

### DIFF
--- a/recipe_viewer.py
+++ b/recipe_viewer.py
@@ -13,6 +13,33 @@ def normalize_unit(value):
     return str(value).strip()
 
 
+def _value_to_text(value):
+    """Convert parsed lists/dicts into a newline string for display."""
+    if isinstance(value, list):
+        lines = []
+        for item in value:
+            if isinstance(item, dict):
+                parts = []
+                qty = item.get("quantity") or item.get("qty")
+                if qty:
+                    parts.append(str(qty))
+                unit = item.get("unit")
+                if unit:
+                    parts.append(str(unit))
+                name = item.get("item") or item.get("name")
+                if name:
+                    parts.append(str(name))
+                else:
+                    parts.append(" ".join(str(v) for v in item.values()))
+                lines.append(" ".join(parts).strip())
+            else:
+                lines.append(str(item))
+        return "\n".join(lines)
+    if isinstance(value, dict):
+        return "\n".join(f"{k}: {v}" for k, v in value.items())
+    return str(value or "")
+
+
 def render_recipe_preview(parsed_data):
     """Display a simple read-only preview of a parsed recipe."""
     recipe = parsed_data.get("recipes", {})
@@ -21,15 +48,10 @@ def render_recipe_preview(parsed_data):
 
     st.subheader("🧪 Auto-Detected Recipe Preview")
 
-    st.text_input("Recipe Name", value=recipe.get("name", ""))
+    st.text_input("Recipe Name", value=recipe.get("name") or recipe.get("title", ""))
 
-    ingredients = recipe.get("ingredients", [])
-    pretty_ingredients = []
-    for i in ingredients:
-        line = f"- {i.get('item', '').title()} ({normalize_quantity(i.get('quantity'))} {normalize_unit(i.get('unit'))})".strip()
-        pretty_ingredients.append(line)
-    st.text_area("Ingredients", value="\n".join(pretty_ingredients))
+    st.text_area("Ingredients", value=_value_to_text(recipe.get("ingredients")))
 
-    st.text_area("Instructions", value=recipe.get("instructions", ""))
-    st.text_area("Notes", value=recipe.get("notes", ""))
+    st.text_area("Instructions", value=_value_to_text(recipe.get("instructions")))
+    st.text_area("Notes", value=_value_to_text(recipe.get("notes")))
 

--- a/recipes.py
+++ b/recipes.py
@@ -68,7 +68,7 @@ def save_recipe_to_firestore(recipe_data, user_id=None, file_id=None):
     recipe_id = str(uuid.uuid4())
     doc = {
         "id": recipe_id,
-        "name": recipe_data.get("title", "Untitled"),
+        "name": recipe_data.get("title") or recipe_data.get("name", "Untitled"),
         "ingredients": recipe_data.get("ingredients", []),
         "instructions": recipe_data.get("instructions", []),
         "tags": recipe_data.get("tags", []),

--- a/recipes_editor.py
+++ b/recipes_editor.py
@@ -8,6 +8,34 @@ from ingredients import parse_recipe_ingredients, update_recipe_with_parsed_ingr
 from allergies import render_allergy_warning
 from recipes import save_recipe_to_firestore
 
+
+def _value_to_text(value):
+    """Convert parsed lists/dicts into a newline-separated string."""
+    if isinstance(value, list):
+        lines = []
+        for item in value:
+            if isinstance(item, dict):
+                parts = []
+                qty = item.get("quantity") or item.get("qty")
+                if qty:
+                    parts.append(str(qty))
+                unit = item.get("unit")
+                if unit:
+                    parts.append(str(unit))
+                name = item.get("item") or item.get("name")
+                if name:
+                    parts.append(str(name))
+                else:
+                    # Fallback to joining dict content
+                    parts.append(" ".join(str(v) for v in item.values()))
+                lines.append(" ".join(parts).strip())
+            else:
+                lines.append(str(item))
+        return "\n".join(lines)
+    if isinstance(value, dict):
+        return "\n".join(f"{k}: {v}" for k, v in value.items())
+    return str(value or "")
+
 # ----------------------------
 # 📖 Recipe Editor UI
 # ----------------------------
@@ -37,13 +65,17 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
     if recipe.get("image_url"):
         st.image(recipe["image_url"], use_column_width=True, caption="📷 Recipe Image")
 
-    st.subheader(f"Editing: {recipe.get('name', 'Unnamed Recipe')}")
+    display_name = recipe.get("name") or recipe.get("title", "Unnamed Recipe")
+    st.subheader(f"Editing: {display_name}")
 
     with st.form("edit_recipe_form"):
-        name = st.text_input("Recipe Name", value=recipe.get("name", ""))
-        ingredients = st.text_area("Ingredients", value=recipe.get("ingredients", ""))
-        instructions = st.text_area("Instructions", value=recipe.get("instructions", ""))
-        notes = st.text_area("Notes", value=recipe.get("notes", ""))
+        name = st.text_input(
+            "Recipe Name",
+            value=recipe.get("name") or recipe.get("title", ""),
+        )
+        ingredients = st.text_area("Ingredients", value=_value_to_text(recipe.get("ingredients")))
+        instructions = st.text_area("Instructions", value=_value_to_text(recipe.get("instructions")))
+        notes = st.text_area("Notes", value=_value_to_text(recipe.get("notes")))
         tags = st.text_input("Tags (comma-separated)", value=", ".join(recipe.get("tags", [])))
         edit_note = st.text_input("📝 Edit Note (for version history)", value="", key="edit_note")
 
@@ -112,13 +144,16 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
                 st.success("✅ Recipe updated!")
             else:
                 # New recipe from parsed data
-                new_id = save_recipe_to_firestore({
-                    "title": name,
-                    "ingredients": ingredients,
-                    "instructions": instructions,
-                    "notes": notes,
-                    "tags": version_entry["tags"]
-                }, user_id=user_id)
+                new_id = save_recipe_to_firestore(
+                    {
+                        "name": name,
+                        "ingredients": ingredients,
+                        "instructions": instructions,
+                        "notes": notes,
+                        "tags": version_entry["tags"],
+                    },
+                    user_id=user_id,
+                )
                 if new_id:
                     st.success("✅ Recipe saved!")
 

--- a/upload.py
+++ b/upload.py
@@ -48,7 +48,10 @@ def upload_ui_desktop(event_id: str = None):
 
             st.markdown("### 🧪 Auto-Detected Recipe Preview")
             with st.form("confirm_recipe_from_upload"):
-                name = st.text_input("Recipe Name", recipe_draft.get("name", ""))
+                name = st.text_input(
+                    "Recipe Name",
+                    recipe_draft.get("name") or recipe_draft.get("title", ""),
+                )
                 ingredients = st.text_area("Ingredients", recipe_draft.get("ingredients", ""))
                 instructions = st.text_area("Instructions", recipe_draft.get("instructions", ""))
                 notes = st.text_area("Notes", recipe_draft.get("notes", ""))


### PR DESCRIPTION
## Summary
- handle `title` or `name` keys for parsed recipes
- update editor save logic
- handle title fallback when previewing recipes
- allow upload recipe form to use either key
- ensure parsed lists populate recipe editor fields properly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `streamlit run app.py` *(fails to open UI but launches)*

------
https://chatgpt.com/codex/tasks/task_e_6852533cdb9883268f76582ed8d642a2