### PR TITLE
Improve upload saving and preview

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -46,32 +46,28 @@ def upload_ui_desktop(event_id: str = None):
         if recipes:
             recipe_draft = recipes if isinstance(recipes, dict) else recipes[0]
             st.session_state["last_recipe_draft"] = recipe_draft
-            with st.expander("Debug Parsed Recipe"):
-                st.json(recipe_draft)
+            with st.expander("🧪 Auto-Detected Recipe", expanded=False):
+                st.caption("Likely: Recipe")
+                with st.form("confirm_recipe_from_upload"):
+                    name = st.text_input(
+                        "Recipe Name",
+                        recipe_draft.get("name") or recipe_draft.get("title", ""),
+                    )
 
-            st.markdown("### 🧪 Auto-Detected Recipe Preview")
-            with st.form("confirm_recipe_from_upload"):
-                name = st.text_input(
-                    "Recipe Name",
-                    recipe_draft.get("name") or recipe_draft.get("title", ""),
-                )
-        aq4cbc-codex/debug-recipe-editor-population-issue
+                    ingredients = st.text_area(
+                        "Ingredients",
+                        value=value_to_text(recipe_draft.get("ingredients")),
+                    )
+                    instructions = st.text_area(
+                        "Instructions",
+                        value=value_to_text(recipe_draft.get("instructions")),
+                    )
+                    notes = st.text_area(
+                        "Notes",
+                        value=value_to_text(recipe_draft.get("notes")),
+                    )
 
-                ingredients = st.text_area(
-                    "Ingredients",
-                    value=value_to_text(recipe_draft.get("ingredients")),
-                )
-                instructions = st.text_area(
-                    "Instructions",
-                    value=value_to_text(recipe_draft.get("instructions")),
-                )
-                notes = st.text_area(
-                    "Notes",
-                    value=value_to_text(recipe_draft.get("notes")),
-                )
-      aq4cbc-codex/debug-recipe-editor-population-issue
-
-                confirm = st.form_submit_button("Save Recipe")
+                    confirm = st.form_submit_button("Save Recipe")
 
                 if eid:
                     st.markdown("### 🍽️ Save as Menu Item for Event")

--- a/upload_integration.py
+++ b/upload_integration.py
@@ -62,7 +62,23 @@ def show_save_file_actions(upload_info: dict):
     raw_text = upload_info.get("raw_text", "")
     uploaded_name = parsed.get("title") or parsed.get("name") or "Unnamed File"
 
+    def _detect_likely(parsed_data: dict):
+        if parsed_data.get("recipes"):
+            return "Recipe"
+        if parsed_data.get("menus"):
+            return "Menu"
+        if parsed_data.get("ingredients"):
+            return "Ingredient"
+        if parsed_data.get("items"):
+            return "Shopping List"
+        if parsed_data.get("events"):
+            return "Event"
+        return None
+
     st.markdown("### 💾 Save File As...")
+    likely = _detect_likely(parsed)
+    if likely:
+        st.caption(f"Likely: {likely}")
     col1, col2, col3 = st.columns(3)
 
     with col1:


### PR DESCRIPTION
## Summary
- save uploaded files to Firestore before parsing
- collapse parsed previews and JSON editors
- display likely entity type next to preview sections

## Testing
- `python -m py_compile upload.py upload_integration.py file_storage.py recipe_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_68531ffba51c8326b43338b92dd1b000