### PR TITLE
Fix indentation error in utils

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -178,7 +178,6 @@ def safe_dict_merge(base, update):
 # ----------------------------
 
 def value_to_text(value):
-        aq4cbc-codex/debug-recipe-editor-population-issue
     """Convert parsed lists or dicts into a newline-separated string.
 
     This helper normalizes parsed recipe values so they can be used to


### PR DESCRIPTION
## Summary
- fix indentation in `utils.py` causing run-time error

## Testing
- `python -m py_compile utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853223c17ec83268b525c0f35e7728b