### PR TITLE
Improve parsed preview workflow

### DIFF
--- a/file_storage.py
+++ b/file_storage.py
@@ -292,7 +292,11 @@ def _render_parsed_data_editor(file: dict, db):
     with st.expander("🧪 Auto-Detected Preview", expanded=False):
         if label:
             st.caption(label)
-        render_recipe_preview(parsed)
+        if st.session_state.get("inline_editor_type") == "recipe":
+            if render_recipe_preview(parsed, allow_edit=True, key_prefix=file["id"]):
+                st.session_state[f"edit_recipe_{file['id']}"] = True
+        else:
+            render_recipe_preview(parsed)
 
     if "inline_editor_type" not in st.session_state:
         edit_key = f"edit_json_{file['id']}"
@@ -329,7 +333,7 @@ def _render_parsed_data_editor(file: dict, db):
                 if st.button("Edit", key=f"start_edit_{file['id']}"):
                     st.session_state[f"edit_mode_{file['id']}"] = True
 
-    if st.session_state.get("inline_editor_type") == "recipe":
+    if st.session_state.get(f"edit_recipe_{file['id']}"):
         st.markdown("### ✏️ Edit This Recipe")
         from recipes_editor import recipe_editor_ui
         recipe_editor_ui(prefill_data=st.session_state["inline_editor_data"])

--- a/recipe_viewer.py
+++ b/recipe_viewer.py
@@ -16,18 +16,49 @@ def normalize_unit(value):
 
 
 
-def render_recipe_preview(parsed_data):
-    """Display a simple read-only preview of a parsed recipe."""
+def render_recipe_preview(parsed_data, allow_edit: bool = False, key_prefix: str = "") -> bool:
+    """Display a read-only preview of a parsed recipe.
+
+    Parameters
+    ----------
+    parsed_data : dict
+        Parsed JSON data containing a ``recipes`` entry.
+    allow_edit : bool, optional
+        Whether to display an ``Edit Recipe`` button.
+    key_prefix : str, optional
+        Prefix for widget keys to avoid collisions.
+
+    Returns
+    -------
+    bool
+        ``True`` if the Edit button was pressed, else ``False``.
+    """
+
     recipe = parsed_data.get("recipes", {})
     if isinstance(recipe, list):
         recipe = recipe[0] if recipe else {}
 
-    st.subheader("🧪 Auto-Detected Recipe Preview")
+    st.markdown(f"#### {recipe.get('name') or recipe.get('title', 'Unnamed Recipe')}")
+    st.text_area(
+        "Ingredients",
+        value=value_to_text(recipe.get("ingredients")),
+        disabled=True,
+        key=f"{key_prefix}_ingredients",
+    )
+    st.text_area(
+        "Instructions",
+        value=value_to_text(recipe.get("instructions")),
+        disabled=True,
+        key=f"{key_prefix}_instructions",
+    )
+    st.text_area(
+        "Notes",
+        value=value_to_text(recipe.get("notes")),
+        disabled=True,
+        key=f"{key_prefix}_notes",
+    )
 
-    st.text_input("Recipe Name", value=recipe.get("name") or recipe.get("title", ""))
-
-    st.text_area("Ingredients", value=value_to_text(recipe.get("ingredients")))
-
-    st.text_area("Instructions", value=value_to_text(recipe.get("instructions")))
-    st.text_area("Notes", value=value_to_text(recipe.get("notes")))
+    if allow_edit:
+        return st.button("✏️ Edit Recipe", key=f"{key_prefix}_edit_btn")
+    return False
 

--- a/upload.py
+++ b/upload.py
@@ -42,59 +42,17 @@ def upload_ui_desktop(event_id: str = None):
 
         st.success(f"✅ File uploaded! File ID: {result['file_id']}")
 
-        recipes = result.get("parsed", {}).get("recipes")
-        if recipes:
-            recipe_draft = recipes if isinstance(recipes, dict) else recipes[0]
-            st.session_state["last_recipe_draft"] = recipe_draft
-            with st.expander("🧪 Auto-Detected Recipe", expanded=False):
-                st.caption("Likely: Recipe")
-                with st.form("confirm_recipe_from_upload"):
-                    name = st.text_input(
-                        "Recipe Name",
-                        recipe_draft.get("name") or recipe_draft.get("title", ""),
-                    )
-
-                    ingredients = st.text_area(
-                        "Ingredients",
-                        value=value_to_text(recipe_draft.get("ingredients")),
-                    )
-                    instructions = st.text_area(
-                        "Instructions",
-                        value=value_to_text(recipe_draft.get("instructions")),
-                    )
-                    notes = st.text_area(
-                        "Notes",
-                        value=value_to_text(recipe_draft.get("notes")),
-                    )
-
-                    confirm = st.form_submit_button("Save Recipe")
-
-                if eid:
-                    st.markdown("### 🍽️ Save as Menu Item for Event")
-                    st.session_state["parsed_recipe_context"] = {
-                        "title": name,
-                        "instructions": instructions,
-                        "notes": notes,
-                        "tags": [],
-                        "allergens": [],
-                        "event_id": eid,
-                    }
-                    save_parsed_menu_ui(st.session_state["parsed_recipe_context"])
-
-                if confirm:
-                    recipe_draft.update({
-                        "name": name,
-                        "ingredients": ingredients,
-                        "instructions": instructions,
-                        "notes": notes,
-                        "tags": [],
-                        "author_name": user.get("name", uploaded_by),
-                    })
-                    recipe_id = save_recipe_to_firestore(recipe_draft)
-                    if recipe_id:
-                        st.success(f"✅ Recipe saved! ID: {recipe_id}")
-                    else:
-                        st.error("❌ Failed to save recipe.")
+        st.session_state["last_upload"] = result
+        if st.button("View Parsed Output", key="show_parsed_after_upload"):
+            from file_storage import _render_parsed_data_editor
+            _render_parsed_data_editor(
+                {
+                    "id": result["file_id"],
+                    "name": file.name,
+                    "parsed_data": {"parsed": result.get("parsed", {})},
+                },
+                get_db(),
+            )
 
     st.markdown("---")
     st.markdown("## 📁 File Manager")


### PR DESCRIPTION
## Summary
- show parsed recipe preview as read-only with optional edit button
- display parsed output viewer from upload page
- allow editing parsed recipes from the preview

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685329df5f7483269fb56ee040c68c66