### PR TITLE
Fix Python module indentation errors

### DIFF
--- a/file_storage.py
+++ b/file_storage.py
@@ -293,7 +293,6 @@ def _render_parsed_data_editor(file: dict, db):
 
     likely = st.session_state.get("inline_editor_type")
     label = f"Likely: {likely.capitalize()}" if likely else ""
-        codex/fix-parsed-info-display-and-recipe-population
     if label:
         st.caption(label)
 

--- a/recipe_viewer.py
+++ b/recipe_viewer.py
@@ -57,7 +57,6 @@ def render_recipe_preview(parsed_data, allow_edit: bool = False, key_prefix: str
         disabled=True,
         key=f"{key_prefix}_notes",
     )
-        codex/fix-parsed-info-display-and-recipe-population
 
     if allow_edit:
         return st.button("✏️ Edit Recipe", key=f"{key_prefix}_edit_btn")

--- a/recipes_editor.py
+++ b/recipes_editor.py
@@ -47,7 +47,6 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
             "Recipe Name",
             value=recipe.get("name") or recipe.get("title", ""),
         )
-        aq4cbc-codex/debug-recipe-editor-population-issue
         ingredients = st.text_area("Ingredients", value=value_to_text(recipe.get("ingredients")))
         instructions = st.text_area("Instructions", value=value_to_text(recipe.get("instructions")))
         notes = st.text_area("Notes", value=value_to_text(recipe.get("notes")))


### PR DESCRIPTION
## Summary
- remove stray codex lines causing syntax errors

## Testing
- `python -m py_compile upload.py file_storage.py recipes_editor.py recipe_viewer.py`


------
https://chatgpt.com/codex/tasks/task_e_685331dcb6e08326a67d5a20eb252ab6