### PR TITLE
Fix recipe name usage after parsing link

### DIFF
--- a/recipes.py
+++ b/recipes.py
@@ -150,7 +150,10 @@ def add_recipe_via_link_ui():
     data = st.session_state.get("parsed_link_recipe")
 
     if data:
-        title = st.text_input("Title", value=data.get("title", ""))
+        title = st.text_input(
+            "Title",
+            value=data.get("name") or data.get("title", ""),
+        )
         ingredients_value = value_to_text(data.get("ingredients"))
         instructions_value = value_to_text(data.get("instructions"))
         ingredients = st.text_area("Ingredients", value=ingredients_value)

--- a/upload_integration.py
+++ b/upload_integration.py
@@ -26,7 +26,10 @@ def save_parsed_menu_ui(parsed_data: dict):
             ["Breakfast", "Lunch", "Dinner", "Note"],
             key="upload_meal_select",
         )
-        recipe = st.text_input("Recipe Name", value=parsed_data.get("title", ""))
+        recipe = st.text_input(
+            "Recipe Name",
+            value=parsed_data.get("name") or parsed_data.get("title", ""),
+        )
         notes = st.text_area("Notes", value=parsed_data.get("notes", ""))
         allergens = st.text_input("Allergens (comma-separated)", value=", ".join(parsed_data.get("allergens", [])))
         tags = st.text_input("Tags (comma-separated)", value=", ".join(parsed_data.get("tags", [])))


### PR DESCRIPTION
## Summary
- use parsed `name` when creating a recipe from a link
- show parsed recipe `name` when saving to event menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68547781c1388326891f47d137abc954