### PR TITLE
Fix recipe parsing from link

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -174,6 +174,18 @@ def safe_dict_merge(base, update):
     return base
 
 # ----------------------------
+# 📑 Normalize Dict Keys
+# ----------------------------
+
+def normalize_keys(obj):
+    """Recursively lowercase dictionary keys for consistent access."""
+    if isinstance(obj, dict):
+        return {str(k).lower(): normalize_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [normalize_keys(v) for v in obj]
+    return obj
+
+# ----------------------------
 # 📝 Convert Parsed Values
 # ----------------------------
 


### PR DESCRIPTION
## Summary
- normalize dictionary key casing in helper
- adjust AI parsing to convert recipe keys to lowercase
- improve recipe validation to check `name` or `title`

## Testing
- `python -m py_compile ai_parsing_engine.py utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582501b3dc832693fdad1778f7fc7c