### PR TITLE
Implement persistent login with remember me option

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,12 @@ import streamlit.components.v1 as components
 
 components.html("""
 <script>
+  const expiry = parseInt(localStorage.getItem('mm_token_expiry') || '0', 10);
+  if (expiry && Date.now() > expiry) {
+    localStorage.removeItem('mm_token');
+    localStorage.removeItem('mm_token_expiry');
+    localStorage.removeItem('mm_remember');
+  }
   const token = localStorage.getItem('mm_token') || "";
   let device = localStorage.getItem('mm_device');
   if (!device) {
@@ -29,10 +35,13 @@ components.html("""
   }
   const handled = localStorage.getItem('mm_token_handled') === 'true';
   const query = `?token=${token}&device=${device}`;
-  if (!window.location.search.includes("token=") && token && !handled) {
+  if (!window.location.search.includes('token=') && token && !handled) {
     localStorage.setItem('mm_token_handled', 'true');
     window.location.href = window.location.pathname + query;
   }
+  window.addEventListener('pagehide', () => {
+    localStorage.setItem('mm_token_handled', 'false');
+  });
 </script>
 """, height=0)
 

--- a/public/index.html
+++ b/public/index.html
@@ -116,8 +116,15 @@
       .then((token) => {
         if (!token) return;
         const deviceType = detectDeviceType();
+        const remember = localStorage.getItem("mm_remember") === "true";
         localStorage.setItem("mm_token", token);
         localStorage.setItem("mm_device", deviceType);
+        if (remember) {
+          const expiry = Date.now() + 30 * 24 * 60 * 60 * 1000;
+          localStorage.setItem("mm_token_expiry", String(expiry));
+        } else {
+          localStorage.removeItem("mm_token_expiry");
+        }
         localStorage.setItem("mm_token_handled", "true");
         window.location.href = `https://mountainmedicine.streamlit.app/?token=${token}&device=${deviceType}`;
       })
@@ -126,6 +133,8 @@
       });
 
     window.login = function () {
+      const remember = document.getElementById('rememberMe').checked;
+      localStorage.setItem('mm_remember', remember ? 'true' : 'false');
       signInWithRedirect(auth, provider);
     }
   </script>
@@ -136,6 +145,9 @@
       <img src="/mountain_logo.png" alt="Mountain Medicine Logo" />
     </div>
     <p>Bringing humanity closer through man's original primal ceremony.</p>
+    <label style="margin-bottom:0.5rem;display:flex;align-items:center;gap:4px;">
+      <input type="checkbox" id="rememberMe" /> Remember me for 30 days
+    </label>
     <button class="login-button" onclick="login()">🔐 Login with Google</button>
     <footer>&copy; 2025 Mountain Medicine</footer>
   </div>


### PR DESCRIPTION
## Summary
- allow auto re-login using stored token by checking expiry and resetting token state on pagehide
- add 30-day remember-me checkbox on the login page
- store token expiry in localStorage when remember-me is selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685897ead28483269c2fc94743345d1d