### PR TITLE
Fix duplicate button key in Events tab

### DIFF
--- a/events.py
+++ b/events.py
@@ -293,7 +293,7 @@ def event_ui(user: dict | None) -> None:
         if active_event:
             st.info(f"🟣 Event Mode Active: **{active_event.get('name', 'Unknown Event')}**")
     
-    for event in events:
+    for idx, event in enumerate(events):
         if event.get("deleted"):
             continue  # Skip deleted events in main view
             
@@ -333,10 +333,10 @@ def event_ui(user: dict | None) -> None:
             
             with col1:
                 # Smart context button (replaces Activate and Start Event)
-                render_smart_event_button(event, user)
+                render_smart_event_button(event, user, key_suffix=str(idx))
 
             with col2:
-                if st.button("Edit", key=f"edit_{event['id']}"):
+                if st.button("Edit", key=f"edit_{event['id']}_{idx}"):
                     st.session_state["editing_event_id"] = event["id"]
                     st.session_state["next_nav"] = "Events"  # force tab to stay
                     st.session_state["show_event_dashboard"] = True
@@ -347,7 +347,7 @@ def event_ui(user: dict | None) -> None:
                             st.session_state.get("user_role") == "admin")
                 
                 if can_delete:
-                    if st.button("Delete", key=f"del_{event['id']}"):
+                    if st.button("Delete", key=f"del_{event['id']}_{idx}"):
                         # Use session state for confirmation
                         confirm_key = f"confirm_delete_{event['id']}"
                         if st.session_state.get(confirm_key):
@@ -363,7 +363,7 @@ def event_ui(user: dict | None) -> None:
                 current_status = event.get('status', 'planning')
                 
                 if current_status == 'active':
-                    if st.button("Complete Event", key=f"complete_{event['id']}"):
+                    if st.button("Complete Event", key=f"complete_{event['id']}_{idx}"):
                         if complete_event_and_end_sessions(event["id"]):
                             st.success("✅ Event marked as complete.")
 

--- a/layout.py
+++ b/layout.py
@@ -980,15 +980,26 @@ def render_enhanced_sidebar():
 # ----------------------------
 # 🎯 Smart Context Buttons
 # ----------------------------
-def render_smart_event_button(event, user):
-    """Render context-aware event button with unique keys"""
+def render_smart_event_button(event, user, key_suffix: str = ""):
+    """Render context-aware event button with unique keys.
+
+    Parameters
+    ----------
+    event : dict
+        Event data dictionary containing at least an ``id`` field.
+    user : dict
+        The currently logged in user.
+    key_suffix : str, optional
+        Extra string appended to the widget key to guarantee uniqueness
+        when this function is called multiple times within loops.
+    """
     from utils import get_active_event_id
     from events import activate_event, deactivate_event_mode, update_event
     
     active_event_id = get_active_event_id()
     event_id = event["id"]
     
-    button_key = f"smart_event_btn_{event_id}"
+    button_key = f"smart_event_btn_{event_id}_{key_suffix}"
     
     if active_event_id == event_id:
         button_text = "🚪 Deactivate Event Mode"


### PR DESCRIPTION
## Summary
- avoid Streamlit duplicate key errors by providing a unique suffix for each event button
- allow `render_smart_event_button` to take an optional key suffix

## Testing
- `python -m py_compile mountainmedicinecatering/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68589f5e13f48326a81807047adac12b