### PR TITLE
Fix duplicate button IDs

### DIFF
--- a/menu_viewer.py
+++ b/menu_viewer.py
@@ -83,7 +83,7 @@ def menu_viewer_ui(event_id=None, key_prefix: str = ""):
             })
             st.success(f"✅ Added: {new_name.strip()}")
 
-    if st.button("💾 Save Menu"):
+    if st.button("💾 Save Menu", key=f"{key_prefix}save_menu_btn"):
         update_event_file_field(event_id, "menu", updated_menu, user_id)
         st.success("✅ Menu saved successfully!")
         st.rerun()

--- a/receipts.py
+++ b/receipts.py
@@ -227,7 +227,11 @@ def _display_receipts(receipts: list) -> None:
 
             with col2:
                 if receipt.get('url'):
-                    st.link_button("📥 Download Original", receipt['url'])
+                    st.link_button(
+                        "📥 Download Original",
+                        receipt['url'],
+                        key=f"download_{receipt['id']}"
+                    )
 
                 if not is_event_scoped() and receipt.get('event_id'):
                     st.markdown(f"**Event ID:** {receipt.get('event_id')}")


### PR DESCRIPTION
## Summary
- add unique key when saving menu items
- add unique key to receipt download links

## Testing
- `python -m py_compile menu_viewer.py receipts.py`

------
https://chatgpt.com/codex/tasks/task_e_6858a2e9eb4c8326bc7e33e4a4db9735