### PR TITLE
Refine events tab layout and date formatting

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -153,9 +153,9 @@ def format_date(ts):
     if not ts:
         return "Unknown"
     if isinstance(ts, datetime):
-        return ts.strftime("%d/%m/%y")  # ← New format
+        return ts.strftime("%m/%d/%y")
     try:
-        return ts.to_datetime().strftime("%d/%m/%y")  # ← New format
+        return ts.to_datetime().strftime("%m/%d/%y")
     except (AttributeError, Exception):
         return str(ts)
 


### PR DESCRIPTION
## Summary
- switch date formatting to `MM/DD/YY`
- show start and end dates side by side in the new event form
- put the new event form in an expander
- rename `Existing Events` section to `📅 All Events`
- sort events by date descending and show date in each event header

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858ce2e29f88326aa440ac189d71802