### PR TITLE
Fix event navigation to planning dashboard

### DIFF
--- a/event_planning_dashboard.py
+++ b/event_planning_dashboard.py
@@ -189,8 +189,8 @@ def event_planning_dashboard_ui(event_id):
     # Menu Planning Section - FIXED
     with st.expander("🍽️ Menu Planning", expanded=True):
         try:
-            # ✅ FIXED: Properly scope the menu editor without affecting global state
-            render_menu_editor_scoped(event_id, user)
+            # ✅ Use the new menu viewer/editor which leverages event_file
+            menu_viewer_ui(event_id=event_id, key_prefix=f"{event_id}_")
         except Exception as e:
             st.error(f"Could not load menu editor: {e}")
             st.info("You can manage menus from the Recipes tab.")
@@ -687,3 +687,12 @@ def _render_ai_suggestions(event_id):
     except Exception as e:
         st.error(f"Failed to generate suggestions: {e}")
         st.info("AI suggestions temporarily unavailable")
+
+
+# ----------------------------
+# 🔄 Backward Compatibility
+# ----------------------------
+
+def event_planning_dashboard(event_id: str):
+    """Compatibility wrapper calling the updated UI function."""
+    return event_planning_dashboard_ui(event_id)

--- a/events.py
+++ b/events.py
@@ -354,15 +354,17 @@ def event_ui(user: dict | None, events: list[dict]) -> None:
         bottom_line = f"{event.get('guest_count', '-') } guests - {event.get('location', 'Unknown')}"
 
         if st.button(top_line, key=f"view_{event['id']}", use_container_width=True):
-            st.session_state["selected_event_id"] = event["id"]
+            st.session_state["editing_event_id"] = event["id"]
+            st.session_state["show_event_dashboard"] = True
+            st.session_state["next_nav"] = "Events"
             st.rerun()
         st.markdown(bottom_line)
 
     if st.session_state.get("show_event_dashboard"):
-        from event_planning_dashboard import event_planning_dashboard
+        from event_planning_dashboard import event_planning_dashboard_ui
         editing_event_id = st.session_state.get("editing_event_id")
         if editing_event_id:
-            event_planning_dashboard(editing_event_id)
+            event_planning_dashboard_ui(editing_event_id)
 
     show_event_mode_banner()
 
@@ -486,7 +488,9 @@ def enhanced_event_ui(user: dict | None) -> None:
             top_line = f"**{name}** {date_str}"
             bottom_line = f"{ev.get('guest_count', '-') } guests - {ev.get('location', 'Unknown')}"
             if st.button(top_line, key=f"upcoming_{ev['id']}", use_container_width=True):
-                st.session_state["selected_event_id"] = ev["id"]
+                st.session_state["editing_event_id"] = ev["id"]
+                st.session_state["show_event_dashboard"] = True
+                st.session_state["next_nav"] = "Events"
                 st.rerun()
             st.markdown(bottom_line)
     else:


### PR DESCRIPTION
## Summary
- make upcoming events and event list open the planning dashboard
- fix import error by aliasing `event_planning_dashboard`
- use `menu_viewer_ui` inside planning dashboard

## Testing
- `python -m py_compile events.py event_planning_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_685976c190808326a09041584a04119d