### PR TITLE
Fix upcoming events click navigation

### DIFF
--- a/events.py
+++ b/events.py
@@ -475,6 +475,14 @@ def enhanced_event_ui(user: dict | None) -> None:
 
     events = get_all_events()
 
+    # If a specific event dashboard was requested, show it immediately
+    if st.session_state.get("show_event_dashboard"):
+        from event_planning_dashboard import event_planning_dashboard_ui
+        editing_event_id = st.session_state.get("editing_event_id")
+        if editing_event_id:
+            event_planning_dashboard_ui(editing_event_id)
+        return
+
     # Upcoming Events section
     st.markdown("### Upcoming Events")
     upcoming = get_upcoming_events(events)


### PR DESCRIPTION
## Summary
- open event planning dashboard when `show_event_dashboard` is set before rendering event list

## Testing
- `python -m py_compile events.py event_planning_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_6859c103585c83269c35bbbbed7ed0e5