### PR TITLE
Implement event dashboard back button and dropdown fix

### DIFF
--- a/event_planning_dashboard.py
+++ b/event_planning_dashboard.py
@@ -58,6 +58,12 @@ def event_planning_dashboard_ui(event_id):
     render_event_toolbar(event_id, context="editing")
 
     st.markdown("# 📝 Event Planning Dashboard")
+
+    if st.button("⬅️ Back", key="epd_back_btn"):
+        st.session_state["show_event_dashboard"] = False
+        st.session_state.pop("editing_event_id", None)
+        st.rerun()
+
     st.info(f"Editing: **{event.get('name', 'Unnamed Event')}**")
 
     # Show basic event info with status

--- a/events.py
+++ b/events.py
@@ -327,6 +327,13 @@ def event_ui(user: dict | None, events: list[dict]) -> None:
         st.warning("Please log in to manage events.")
         return
 
+    if st.session_state.get("show_event_dashboard"):
+        from event_planning_dashboard import event_planning_dashboard_ui
+        editing_event_id = st.session_state.get("editing_event_id")
+        if editing_event_id:
+            event_planning_dashboard_ui(editing_event_id)
+        return
+
     # Detail view of a single event
     selected_id = st.session_state.pop("selected_event_id", None)
     if selected_id:
@@ -472,6 +479,13 @@ def filter_events(events, search_term, status_filter, date_filter):
 
 def enhanced_event_ui(user: dict | None) -> None:
     """Reimagined event UI with upcoming events and expandable sections."""
+
+    if st.session_state.get("show_event_dashboard"):
+        from event_planning_dashboard import event_planning_dashboard_ui
+        editing_event_id = st.session_state.get("editing_event_id")
+        if editing_event_id:
+            event_planning_dashboard_ui(editing_event_id)
+        return
 
     events = get_all_events()
 

--- a/mobile_style.css
+++ b/mobile_style.css
@@ -231,6 +231,7 @@ button:active, .stButton > button:active {
     border-radius: var(--border-radius) !important;
     padding: 0.75rem !important;
     font-size: 1rem !important;
+    color: #000000 !important;
 }
 
 /* Touch-friendly checkboxes */

--- a/style.css
+++ b/style.css
@@ -249,6 +249,7 @@ button:active, .stButton > button:active {
     border-radius: var(--border-radius) !important;
     padding: 0.75rem !important;
     font-size: 1rem !important;
+    color: #000000 !important;
 }
 
 /* Touch-friendly checkboxes */


### PR DESCRIPTION
## Summary
- add Back button to the event planning dashboard
- hide event lists when the planning dashboard is active
- ensure dropdown text remains visible

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859c38c249883269f0618d7671b5266