### PR TITLE
Improve event refresh workflow

### DIFF
--- a/events.py
+++ b/events.py
@@ -4,7 +4,6 @@ import streamlit as st
 from utils import get_active_event_id, format_date, generate_id
 from ui_components import show_event_mode_banner
 from layout import render_status_indicator
-from event_file import generate_menu_template
 from datetime import datetime
 from firebase_init import db, firestore
 
@@ -162,10 +161,8 @@ def create_event(event_data: dict, user_id: str) -> str:
         db.collection("events").document(event_id).set(event_data)
 
          # ✅ Create canonical event_file under /events/{eventId}/meta/event_file
-        default_menu = generate_menu_template(event_data.get("start_date"), event_data.get("end_date"))
-
         db.collection("events").document(event_id).collection("meta").document("event_file").set({
-            "menu": default_menu,
+            "menu": [],
             "menu_html": "",
             "schedule": [],
             "equipment": [],
@@ -282,6 +279,7 @@ def render_create_event_section(user: dict) -> None:
                     event_id = create_event(event_data, user["id"])
                     if event_id:
                         st.success(f"✅ Event created: {name}")
+                        st.rerun()
 
 # ----------------------------
 # 🆕 Event Details Page
@@ -357,12 +355,25 @@ def event_ui(user: dict | None, events: list[dict]) -> None:
         top_line = f"**{name}** {date_str}"
         bottom_line = f"{event.get('guest_count', '-') } guests - {event.get('location', 'Unknown')}"
 
-        if st.button(top_line, key=f"view_{event['id']}", use_container_width=True):
-            st.session_state["editing_event_id"] = event["id"]
-            st.session_state["show_event_dashboard"] = True
-            st.session_state["next_nav"] = "Events"
-            st.rerun()
-        st.markdown(bottom_line)
+        col1, col2 = st.columns([8, 1])
+        with col1:
+            if st.button(top_line, key=f"view_{event['id']}", use_container_width=True):
+                st.session_state["editing_event_id"] = event["id"]
+                st.session_state["show_event_dashboard"] = True
+                st.session_state["next_nav"] = "Events"
+                st.rerun()
+            st.markdown(bottom_line)
+
+        can_delete = (
+            user.get("id") == event.get("created_by")
+            or st.session_state.get("user_role") == "admin"
+        )
+        if can_delete:
+            with col2:
+                if st.button("🗑️", key=f"del_{event['id']}"):
+                    if delete_event(event["id"]):
+                        st.success("Event deleted")
+                        st.rerun()
 
     if st.session_state.get("show_event_dashboard"):
         from event_planning_dashboard import event_planning_dashboard_ui
@@ -506,12 +517,28 @@ def enhanced_event_ui(user: dict | None) -> None:
             date_str = format_date(ev.get("start_date"))
             top_line = f"**{name}** {date_str}"
             bottom_line = f"{ev.get('guest_count', '-') } guests - {ev.get('location', 'Unknown')}"
-            if st.button(top_line, key=f"upcoming_{ev['id']}", use_container_width=True):
-                st.session_state["editing_event_id"] = ev["id"]
-                st.session_state["show_event_dashboard"] = True
-                st.session_state["next_nav"] = "Events"
-                st.rerun()
-            st.markdown(bottom_line)
+
+            col1, col2 = st.columns([8, 1])
+            with col1:
+                if st.button(top_line, key=f"upcoming_{ev['id']}", use_container_width=True):
+                    st.session_state["editing_event_id"] = ev["id"]
+                    st.session_state["show_event_dashboard"] = True
+                    st.session_state["next_nav"] = "Events"
+                    st.rerun()
+                st.markdown(bottom_line)
+
+            can_delete = (
+                user and (
+                    user.get("id") == ev.get("created_by")
+                    or st.session_state.get("user_role") == "admin"
+                )
+            )
+            if can_delete:
+                with col2:
+                    if st.button("🗑️", key=f"del_up_{ev['id']}"):
+                        if delete_event(ev["id"]):
+                            st.success("Event deleted")
+                            st.rerun()
     else:
         st.write("No upcoming events.")
 

--- a/menu.txt
+++ b/menu.txt
@@ -1,0 +1,18 @@
+The menu subsystem manages menu items for each event. When a new event is
+created the application stores a canonical `event_file` document under
+`/events/{eventId}/meta/event_file`. This document now starts with an empty
+`menu` list instead of pre‑generated meal entries.
+
+`menu_viewer_ui` provides the interface for viewing and editing an event’s
+menu. Each existing item is editable in place and all changes are persisted to
+the `event_file`. Adding a menu item immediately updates the stored JSON and
+refreshes the interface so no separate save step is required.
+
+`menu_editor_ui` (used less frequently) follows the same pattern—all menu
+entries are written back to the event document automatically when the screen is
+rendered.
+
+These changes remove the previous logic that generated placeholder menu items
+based on event duration and eliminate the explicit “Save Menu” buttons. Menu
+items are stored per event and are displayed in the event planning dashboard
+through the menu viewer component.

--- a/menu_editor.py
+++ b/menu_editor.py
@@ -1,7 +1,6 @@
 import streamlit as st
 from firebase_init import db
 from utils import get_active_event_id, generate_id
-from event_file import generate_menu_template
 from auth import get_user_id
 from datetime import datetime
 import json
@@ -84,11 +83,7 @@ def full_menu_editor_ui(event_id=None, key_prefix: str = ""):
     data = doc.to_dict()
     menu = data.get("menu", [])
 
-    # Auto-generate blank menu for each event day if empty
-    if not menu:
-        event_doc = db.collection("events").document(event_id).get()
-        event_data = event_doc.to_dict() if event_doc.exists else {}
-        menu = generate_menu_template(event_data.get("start_date", ""), event_data.get("end_date", ""))
+    # Leave menu empty if none exists
 
     st.markdown("### 📋 Current Menu")
     meal_colors = {
@@ -132,13 +127,13 @@ def full_menu_editor_ui(event_id=None, key_prefix: str = ""):
                 "tags": []
             })
 
-    if st.button("💾 Save Menu"):
-        ref.update({
-            "menu": updated_menu,
-            "last_updated": datetime.utcnow(),
-            "updated_by": user_id
-        })
-        st.success("✅ Menu saved successfully!")
+    # Automatically persist changes without an explicit save button
+    ref.update({
+        "menu": updated_menu,
+        "last_updated": datetime.utcnow(),
+        "updated_by": user_id
+    })
+    st.success("✅ Menu updated!")
 
 # ----------------------------
 # 🔧 Helpers

--- a/menu_viewer.py
+++ b/menu_viewer.py
@@ -65,6 +65,10 @@ def menu_viewer_ui(event_id=None, key_prefix: str = "", show_headers: bool = Tru
                 "tags": [t.strip() for t in tags.split(",") if t.strip()]
             })
 
+    # Persist edits to existing items on each interaction
+    if updated_menu != menu:
+        update_event_file_field(event_id, "menu", updated_menu, user_id)
+
     with st.expander("➕ Add New Menu Item", expanded=False):
         form_key = f"{key_prefix}new_menu_item_form"
         with st.form(form_key, clear_on_submit=True):
@@ -108,12 +112,11 @@ def menu_viewer_ui(event_id=None, key_prefix: str = "", show_headers: bool = Tru
                     "description": new_description.strip(),
                     "tags": []
                 })
+                update_event_file_field(event_id, "menu", updated_menu, user_id)
                 st.success(f"✅ Added: {new_name.strip()}")
+                st.rerun()
 
-    if st.button("💾 Save Menu", key=f"{key_prefix}save_menu_btn"):
-        update_event_file_field(event_id, "menu", updated_menu, user_id)
-        st.success("✅ Menu saved successfully!")
-        st.rerun()
+
 
 # ----------------------------
 # 🔧 Helpers


### PR DESCRIPTION
## Summary
- refresh events list immediately after creating a new event
- show delete buttons for events in both upcoming and all event lists

## Testing
- `python -m py_compile menu_viewer.py menu_editor.py events.py event_planning_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_6859f02af90483269cfeb6a23006aac3