### PR TITLE
Add recipe photo parsing

### DIFF
--- a/recipes.py
+++ b/recipes.py
@@ -82,6 +82,7 @@ def save_recipe_to_firestore(recipe_data, user_id=None, file_id=None):
         "ingredients": recipe_data.get("ingredients", []),
         "instructions": recipe_data.get("instructions", []),
         "special_version": recipe_data.get("special_version", ""),
+        "image_url": recipe_data.get("image_url"),
         "tags": recipe_data.get("tags", []),
         "created_by": user_id,
         "source_file_id": file_id,


### PR DESCRIPTION
## Summary
- parse image data from uploads
- extract OG image when parsing recipe URLs
- save `image_url` when writing recipes to Firestore

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a0797f0d4832688f917acdde734b4