### PR TITLE
Fix image display for recipes

### DIFF
--- a/receipts.py
+++ b/receipts.py
@@ -278,7 +278,8 @@ def _upload_receipt_section(user: dict) -> None:
         with col1:
             if uploaded.type.startswith('image'):
                 image = Image.open(uploaded)
-                st.image(image, caption="Receipt Preview", use_column_width=True)
+                # Preview the uploaded receipt image with a standard width
+                st.image(image, caption="Receipt Preview", width=400)
 
         with col2:
             st.info("📸 Receipt uploaded! Click below to analyze it.")

--- a/recipes.py
+++ b/recipes.py
@@ -175,7 +175,8 @@ def add_recipe_via_link_ui():
         instructions = st.text_area("Instructions", value=instructions_value)
         image_file = st.file_uploader("Recipe Photo", type=["png", "jpg", "jpeg"])
         if image_file:
-            st.image(image_file, use_column_width=True)
+            # Display a preview of the uploaded image with a standard width
+            st.image(image_file, width=400)
 
         if st.button("Save Recipe", key="save_link_recipe"):
             user = get_user()
@@ -267,7 +268,10 @@ def _render_recipe_card(recipe: dict):
 
     with st.expander(recipe.get("name", "Unnamed")):
         if recipe.get("image_url"):
-            st.image(recipe["image_url"], use_column_width=True)
+            # Center the image and standardize its display size
+            col_center = st.columns([1, 6, 1])[1]
+            with col_center:
+                st.image(recipe["image_url"], width=400)
         st.markdown("#### Ingredients")
         st.markdown(recipe.get("ingredients", ""))
         st.markdown("#### Instructions")

--- a/recipes_editor.py
+++ b/recipes_editor.py
@@ -47,7 +47,8 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
         return
 
     if recipe.get("image_url"):
-        st.image(recipe["image_url"], use_column_width=True, caption="📷 Recipe Image")
+        # Display the recipe image with a consistent size
+        st.image(recipe["image_url"], width=400, caption="📷 Recipe Image")
 
     display_name = recipe.get("name") or recipe.get("title", "Unnamed Recipe")
     st.subheader(f"Editing: {display_name}")


### PR DESCRIPTION
## Summary
- update deprecated Streamlit options
- center and size recipe images in the viewer
- standardize image preview sizes when editing recipes and receipts

## Testing
- `python -m py_compile recipes.py recipes_editor.py receipts.py`


------
https://chatgpt.com/codex/tasks/task_e_685a0abf0b008326be974a275408a372