### PR TITLE
Improve navigation styling & update login title

### DIFF
--- a/layout.py
+++ b/layout.py
@@ -813,9 +813,10 @@ def render_top_navbar(tabs):
     .stRadio > div > label {
         flex: 1 1 auto !important;
         background: transparent !important;
-        color: rgba(255,255,255,0.6) !important;
+        color: #ffffff !important;
+        opacity: 0.85 !important;
         border: none !important;
-        border-right: 1px solid rgba(255,255,255,0.3) !important;
+        border-right: 1px solid rgba(255,255,255,0.4) !important;
         border-radius: 0 !important;
         padding: 0.5rem 1rem !important;
         font-weight: 500 !important;
@@ -826,8 +827,9 @@ def render_top_navbar(tabs):
         border-right: none !important;
     }
     .stRadio > div > label[aria-checked="true"] {
-        background: var(--dark-purple, #4a3280) !important;
+        background: var(--accent-purple, #563a9d) !important;
         color: #fff !important;
+        opacity: 1 !important;
     }
     .stRadio input[type="radio"] { display: none !important; }
     </style>

--- a/mobile_style.css
+++ b/mobile_style.css
@@ -94,28 +94,39 @@ button:active, .stButton > button:active {
 
 .stRadio > div {
     display: flex !important;
-    gap: 0.5rem !important;
-    overflow-x: auto !important;
-    -webkit-overflow-scrolling: touch !important;
-    padding-bottom: 0.5rem !important;
+    gap: 0 !important;
+    overflow: hidden !important;
+    background: var(--primary-purple, #6C4AB6) !important;
+    border-radius: var(--border-radius) !important;
 }
 
 .stRadio > div > label {
-    background: white !important;
-    color: var(--primary-purple) !important;
-    border: 2px solid var(--primary-purple) !important;
-    border-radius: var(--border-radius) !important;
+    flex: 1 1 auto !important;
+    background: transparent !important;
+    color: #ffffff !important;
+    opacity: 0.85 !important;
+    border: none !important;
+    border-right: 1px solid rgba(255, 255, 255, 0.4) !important;
+    border-radius: 0 !important;
     padding: 0.75rem 1.25rem !important;
     font-weight: 500 !important;
     font-size: 0.9rem !important;
     cursor: pointer !important;
     transition: var(--transition) !important;
     min-height: var(--touch-target-size) !important;
-    display: inline-flex !important;
+    display: flex !important;
     align-items: center !important;
     justify-content: center !important;
     white-space: nowrap !important;
-    flex-shrink: 0 !important;
+    list-style: none !important;
+}
+.stRadio > div > label:last-child {
+    border-right: none !important;
+}
+.stRadio > div > label[aria-checked="true"] {
+    background: var(--accent-purple, #563a9d) !important;
+    color: #ffffff !important;
+    opacity: 1 !important;
 }
 
 /* -----------------------------

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Login | Mountain Medicine</title>
+  <title>Mountain Medicine - Login</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
     :root {

--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ button:active, .stButton > button:active {
     min-width: max-content !important;
 }
 
+
 .stRadio > div {
     display: flex !important;
     gap: 0 !important;
@@ -103,9 +104,10 @@ button:active, .stButton > button:active {
 .stRadio > div > label {
     flex: 1 1 auto !important;
     background: transparent !important;
-    color: rgba(255, 255, 255, 0.6) !important;
+    color: #ffffff !important;
+    opacity: 0.85 !important;
     border: none !important;
-    border-right: 1px solid rgba(255, 255, 255, 0.3) !important;
+    border-right: 1px solid rgba(255, 255, 255, 0.4) !important;
     border-radius: 0 !important;
     padding: 0.75rem 1.25rem !important;
     font-weight: 500 !important;
@@ -123,8 +125,9 @@ button:active, .stButton > button:active {
     border-right: none !important;
 }
 .stRadio > div > label[aria-checked="true"] {
-    background: var(--dark-purple, #4a3280) !important;
+    background: var(--accent-purple, #563a9d) !important;
     color: #ffffff !important;
+    opacity: 1 !important;
 }
 .stRadio input[type="radio"] {
     display: none !important;


### PR DESCRIPTION
## Summary
- update login page title for bookmarks
- boost nav tab contrast in desktop and mobile CSS
- apply same styles in layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a13759314832685b5f00f84752202