### PR TITLE
Fix ingredient formatting

### DIFF
--- a/ai_chat.py
+++ b/ai_chat.py
@@ -2,7 +2,7 @@ import streamlit as st
 from datetime import datetime
 from auth import get_user_role
 from firebase_init import db
-from utils import format_date, generate_id, get_active_event, get_active_event_id
+from utils import format_date, generate_id, get_active_event, get_active_event_id, value_to_text
 import json
 from google.cloud.firestore_v1.base_query import FieldFilter
 from firebase_admin import firestore
@@ -88,8 +88,8 @@ def ai_chat_ui():
         with st.expander("📘 Recipe Context (linked)", expanded=False):
             st.markdown(f"**Name:** {recipe_context.get('name', 'Unnamed')}")
             st.markdown(f"**Author:** {recipe_context.get('author_name', 'Unknown')}")
-            st.markdown(f"**Ingredients:**\n{recipe_context.get('ingredients', '—')}")
-            st.markdown(f"**Instructions:**\n{recipe_context.get('instructions', '—')}")
+            st.markdown(f"**Ingredients:**\n{value_to_text(recipe_context.get('ingredients', ''))}")
+            st.markdown(f"**Instructions:**\n{value_to_text(recipe_context.get('instructions', ''))}")
             if st.button("🧠 Ask AI about this recipe"):
                 st.session_state.chat_history.append({
                     "sender": "user",

--- a/recipes.py
+++ b/recipes.py
@@ -47,6 +47,8 @@ def parse_and_store_recipe_from_file(file_text: str, uploaded_by: str) -> str | 
 
     ingredients = "\n".join(lines[ingredients_start:instructions_start]).strip()
     instructions = "\n".join(lines[instructions_start:]).strip()
+    ingredients = value_to_text(ingredients)
+    instructions = value_to_text(instructions)
 
     recipe_data = {
         "id": str(uuid.uuid4()),
@@ -79,8 +81,8 @@ def save_recipe_to_firestore(recipe_data, user_id=None, file_id=None):
     doc = {
         "id": recipe_id,
         "name": recipe_data.get("title") or recipe_data.get("name", "Untitled"),
-        "ingredients": recipe_data.get("ingredients", []),
-        "instructions": recipe_data.get("instructions", []),
+        "ingredients": value_to_text(recipe_data.get("ingredients", [])),
+        "instructions": value_to_text(recipe_data.get("instructions", [])),
         "special_version": recipe_data.get("special_version", ""),
         "image_url": recipe_data.get("image_url"),
         "tags": recipe_data.get("tags", []),
@@ -280,9 +282,9 @@ def _render_recipe_card(recipe: dict):
             with col_center:
                 st.image(recipe["image_url"], width=400)
         st.markdown("#### Ingredients")
-        st.markdown(recipe.get("ingredients", ""))
+        st.markdown(value_to_text(recipe.get("ingredients", "")))
         st.markdown("#### Instructions")
-        st.markdown(recipe.get("instructions", ""))
+        st.markdown(value_to_text(recipe.get("instructions", "")))
         if recipe.get("notes"):
             st.markdown("#### Notes")
             st.markdown(recipe.get("notes"))
@@ -302,9 +304,21 @@ def _render_recipe_card(recipe: dict):
             with st.form(f"ver_form_{recipe['id']}"):
                 name = st.text_input("Title", value=recipe.get("name", ""), key=f"ver_name_{recipe['id']}")
                 special_version = st.text_input("Special Version", value=recipe.get("special_version", ""), key=f"ver_sp_{recipe['id']}")
-                ingredients = st.text_area("Ingredients", value=recipe.get("ingredients", ""), key=f"ver_ing_{recipe['id']}")
-                instructions = st.text_area("Instructions", value=recipe.get("instructions", ""), key=f"ver_inst_{recipe['id']}")
-                notes = st.text_area("Notes", value=recipe.get("notes", ""), key=f"ver_notes_{recipe['id']}")
+                ingredients = st.text_area(
+                    "Ingredients",
+                    value=value_to_text(recipe.get("ingredients")),
+                    key=f"ver_ing_{recipe['id']}"
+                )
+                instructions = st.text_area(
+                    "Instructions",
+                    value=value_to_text(recipe.get("instructions")),
+                    key=f"ver_inst_{recipe['id']}"
+                )
+                notes = st.text_area(
+                    "Notes",
+                    value=value_to_text(recipe.get("notes")),
+                    key=f"ver_notes_{recipe['id']}"
+                )
                 tags = st.text_input("Tags (comma-separated)", value=", ".join(recipe.get("tags", [])), key=f"ver_tags_{recipe['id']}")
                 col_c, col_s = st.columns(2)
                 save = col_s.form_submit_button("Save")


### PR DESCRIPTION
## Summary
- convert ingredient lists to newline text when saving
- display ingredients vertically in recipe cards, editors, and chat context

## Testing
- `python -m py_compile recipes.py ai_chat.py recipe_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_685a17a6b00c8326b4e0f61d529f3876