### PR TITLE
Improve session refresh and fix recipe tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,9 +40,30 @@ components.html("""
     localStorage.setItem('mm_token_handled', 'true');
     window.location.href = window.location.pathname + query;
   }
+  const refreshSession = () => {
+    const token = localStorage.getItem('mm_token') || "";
+    const device = localStorage.getItem('mm_device') || 'desktop';
+    const handled = localStorage.getItem('mm_token_handled') === 'true';
+    if (!window.location.search.includes('token=') && token && !handled) {
+      localStorage.setItem('mm_token_handled', 'true');
+      window.location.href = window.location.pathname + `?token=${token}&device=${device}`;
+    }
+  };
+
   window.addEventListener('pagehide', () => {
     localStorage.setItem('mm_token_handled', 'false');
   });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      localStorage.setItem('mm_token_handled', 'false');
+    } else if (document.visibilityState === 'visible') {
+      refreshSession();
+    }
+  });
+
+  window.addEventListener('pageshow', refreshSession);
+  window.addEventListener('focus', refreshSession);
 </script>
 """, height=0)
 

--- a/mobile_style.css
+++ b/mobile_style.css
@@ -128,6 +128,9 @@ button:active, .stButton > button:active {
     color: #ffffff !important;
     opacity: 1 !important;
 }
+.stRadio > div > label[aria-checked="true"] * {
+    color: #ffffff !important;
+}
 
 /* -----------------------------
    MOBILE CHAT INTERFACE

--- a/recipes.py
+++ b/recipes.py
@@ -153,7 +153,7 @@ def add_recipe_via_link_ui():
             placeholder="Just paste a link to an online recipe",
             key="recipe_link_input",
         )
-        parse_clicked = st.button("Parse", key="parse_link_btn")
+        parse_clicked = st.button("Get Recipe", key="parse_link_btn")
 
         if parse_clicked and url:
             with st.spinner("Parsing recipe..."):
@@ -223,6 +223,7 @@ def add_recipe_via_link_ui():
                 st.session_state["link_ingredients"] = ""
                 st.session_state["link_instructions"] = ""
                 st.session_state["link_image_upload"] = None
+                st.rerun()
 
         st.markdown("</div>", unsafe_allow_html=True)
 
@@ -282,6 +283,7 @@ def add_recipe_manual_ui():
             st.session_state["manual_instructions"] = ""
             st.session_state["manual_notes"] = ""
             st.session_state["manual_tags"] = ""
+            st.rerun()
         except Exception as e:
             st.error(f"Failed to save recipe: {e}")
 

--- a/style.css
+++ b/style.css
@@ -129,6 +129,9 @@ button:active, .stButton > button:active {
     color: #ffffff !important;
     opacity: 1 !important;
 }
+.stRadio > div > label[aria-checked="true"] * {
+    color: #ffffff !important;
+}
 .stRadio input[type="radio"] {
     display: none !important;
 }


### PR DESCRIPTION
## Summary
- refresh token on pageshow/focus events for iOS backgrounding
- rerun recipe page after saving recipes so list reloads

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ab2a679e48326b056f2df45e3cb97