### PR TITLE
Change login redirect flow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -133,7 +133,8 @@
           if (token) {
             const device = detectDevice();
             saveToken(token, device);
-            redirect(token, device);
+            // redirect to intermediate page
+            window.location.href = "/redirect.html";
           }
         });
     }

--- a/public/redirect.html
+++ b/public/redirect.html
@@ -5,14 +5,15 @@
   <title>Redirecting...</title>
   <script>
     window.onload = function() {
-      const params = new URLSearchParams(window.location.search);
-      const token = params.get("token");
-      const device = params.get("device") || "desktop";
-      if (token) {
+      const token = localStorage.getItem("mm_token");
+      const device = localStorage.getItem("mm_device") || "desktop";
+      const expiry = parseInt(localStorage.getItem("mm_token_expiry") || "0", 10);
+
+      if (token && Date.now() < expiry) {
         const dest = `https://mountainmedicine.streamlit.app/?token=${token}&device=${device}`;
         window.location.replace(dest);
       } else {
-        document.body.innerHTML = "<h1>Error: No token found</h1>";
+        document.body.innerHTML = "<h1>Session expired. Please <a href='/'>log in again</a>.</h1>";
       }
     };
   </script>


### PR DESCRIPTION
## Summary
- after a new login redirect to a dedicated intermediate page
- read token and device info from localStorage in the redirect page
- if the session expired, prompt user to log in again

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b268defb083268cf2a291b07a887a