### PR TITLE
fix: auto-reauth on missing or expired Firebase token

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -127,15 +127,15 @@
           const token = await user.getIdToken(true);  // force refresh
           const device = detectDevice();
           saveToken(token, device);
-          redirectIfReady();
+          window.location.href = "/redirect.html";
         } catch (err) {
           console.error("Token refresh failed:", err);
-          // Show login button
-          document.getElementById("loginBtn").style.display = "block";
+          // Force reauth
+          signInWithRedirect(auth, provider);
         }
       } else {
-        // Not logged in, show login button
-        document.getElementById("loginBtn").style.display = "block";
+        // No user: trigger login immediately
+        signInWithRedirect(auth, provider);
       }
     });
 


### PR DESCRIPTION
## Summary
- ensure users are automatically re-authenticated if the Firebase token fails or no user is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0420a37c832689c2dc11ebf5bc1d