### PR TITLE
Fix Firebase token expiry recovery

### DIFF
--- a/code.txt
+++ b/code.txt
@@ -2612,6 +2612,17 @@ def handle_auth_routing():
             st.query_params.clear()
         else:
             st.error("Login failed. Invalid or expired token.")
+            import streamlit.components.v1 as components
+            components.html("""
+              <script>
+                localStorage.removeItem('mm_token');
+                localStorage.removeItem('mm_token_expiry');
+                localStorage.removeItem('mm_remember');
+                const fallback = localStorage.getItem('mm_device') || 'desktop';
+                window.location.href = '/?forceLogin=true&device=' + fallback;
+              </script>
+            """, height=0)
+            st.stop()
             return
 
     elif not get_user():
@@ -5586,6 +5597,17 @@ def handle_auth_routing():
             st.query_params.clear()
         else:
             st.error("Login failed. Invalid or expired token.")
+            import streamlit.components.v1 as components
+            components.html("""
+              <script>
+                localStorage.removeItem('mm_token');
+                localStorage.removeItem('mm_token_expiry');
+                localStorage.removeItem('mm_remember');
+                const fallback = localStorage.getItem('mm_device') || 'desktop';
+                window.location.href = '/?forceLogin=true&device=' + fallback;
+              </script>
+            """, height=0)
+            st.stop()
             return
 
     elif not get_user():

--- a/public/index.html
+++ b/public/index.html
@@ -120,6 +120,13 @@
       window.location.href = "/redirect.html";
     }
 
+    // Detect forced reauth from Streamlit app
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("forceLogin") === "true") {
+      console.warn("Forced reauthentication triggered by app.");
+      signInWithRedirect(auth, provider);
+    }
+
     // Modern persistent login flow
     onAuthStateChanged(auth, async (user) => {
       if (user) {


### PR DESCRIPTION
## Summary
- detect `forceLogin` parameter to trigger reauth
- clear local storage and redirect when token invalid in app

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c07534ae883268c9e7f6c2f6e67e5