### PR TITLE
fix: auto-recover from expired Firebase token via reauth redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -199,6 +199,16 @@ def handle_auth_routing():
             st.query_params.clear()
         else:
             st.error("Login failed. Invalid or expired token.")
+            components.html("""
+              <script>
+                localStorage.removeItem("mm_token");
+                localStorage.removeItem("mm_token_expiry");
+                localStorage.removeItem("mm_remember");
+                const device = localStorage.getItem("mm_device") || "desktop";
+                window.location.href = `/login?forceLogin=true&device=${device}`;
+              </script>
+            """, height=0)
+            st.stop()
             return
 
     elif not get_user():

--- a/public/index.html
+++ b/public/index.html
@@ -123,6 +123,11 @@
     // Detect forced reauth from Streamlit app
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get("forceLogin") === "true") {
+      const device = /iphone|ipad|android/i.test(navigator.userAgent) ? "mobile" : "desktop";
+      localStorage.setItem("mm_device", device);
+      localStorage.removeItem("mm_token");
+      localStorage.removeItem("mm_token_expiry");
+      localStorage.removeItem("mm_token_handled");
       console.warn("Forced reauthentication triggered by app.");
       signInWithRedirect(auth, provider);
     }


### PR DESCRIPTION
## Summary
- handle invalid Firebase tokens by clearing client storage and redirecting to login
- on the login page, capture `forceLogin` parameter and trigger a fresh redirect

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c2b149d8c8326b0e938bfbdf5b44d