### PR TITLE
Add custom styling to hide Streamlit system UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,15 @@ st.set_page_config(
     initial_sidebar_state="collapsed"
 )
 
+# Hide Streamlit system UI elements (menu, deploy button, footer)
+st.markdown("""
+<style>
+#MainMenu, .stDeployButton, footer, header {
+    visibility: hidden;
+}
+</style>
+""", unsafe_allow_html=True)
+
 st.markdown("""
 <style>
 div[data-testid='stRadio'] > label {


### PR DESCRIPTION
## Summary
- hide Streamlit menu, deploy button, footer and header with injected CSS

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685c4d888ec0832696ecc4bcb4b04b8c