### PR TITLE
Fix stray brace causing syntax error

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,8 +157,6 @@ def handle_auth():
 
         user = enrich_session_from_token(token)
 
-        })
-
         if user:
             st.session_state["user"] = user
             st.toast(f"Welcome {user.get('name', 'back')} 👋")


### PR DESCRIPTION
## Summary
- remove a leftover `})` in `handle_auth`

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d9c05b8588326a640950b99c8c337