### PR TITLE
Fix login flow and logout issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,7 +144,16 @@ def handle_auth():
         st.session_state.clear()
         st.session_state.update(preserved)
         st.toast("You have been logged out")
-        st.switch_page("/login")
+        components.html("""
+        <script>
+          localStorage.removeItem('mm_token');
+          localStorage.removeItem('mm_token_expiry');
+          localStorage.removeItem('mm_token_handled');
+          localStorage.removeItem('mm_device');
+          window.location.href='/?forceLogin=true';
+        </script>
+        """, height=0)
+        st.stop()
 
     if "token" in query_params and "user" not in st.session_state:
         token = query_params.get("token")
@@ -182,7 +191,7 @@ def handle_auth():
         if (token) {
           window.location.href = window.location.pathname + `?token=${token}&device=${device}`;
         } else {
-          window.location.href = "/login";
+          window.location.href = "/?forceLogin=true";
         }
         </script>
         """, height=0)
@@ -252,8 +261,6 @@ def main():
     if user:
         st.session_state["user"] = user
         st.session_state["token_expiry"] = user.get("token_expiry")  # ✅ Add this line
-        st.toast(f"Welcome {user.get('name', 'back')} 👋")
-        log_user_action(user.get("id", "unknown"), user.get("role", "viewer"), "login")
         st.query_params.clear()
     if role != "admin":
         for admin_tab in ["Admin Panel"]:

--- a/layout.py
+++ b/layout.py
@@ -1105,14 +1105,12 @@ def render_login_status_button():
         name = user.get("name") or user.get("email")
         st.markdown(f"""
         <div style='position: fixed; top: 1rem; right: 1rem; z-index: 999;'>
-            <form action='/' method='post'>
-                <button onclick=\"window.location.href='/?logout=true'\">🔓 {name}</button>
-            </form>
+            <button onclick=\"window.location.href='/?logout=true'\">🔓 {name}</button>
         </div>
         """, unsafe_allow_html=True)
     else:
         st.markdown("""
         <div style='position: fixed; top: 1rem; right: 1rem; z-index: 999;'>
-            <button onclick=\"window.location.href='/login'\">🔐 Login</button>
+            <button onclick=\"window.location.href='/?forceLogin=true'\">🔐 Login</button>
         </div>
         """, unsafe_allow_html=True)

--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
   </style>
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js";
-    import { getAuth, GoogleAuthProvider, signInWithRedirect, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js";
+    import { getAuth, GoogleAuthProvider, signInWithRedirect, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js";
     const firebaseConfig = {
       apiKey: "AIzaSyBSpwzSf8hXxb4rBk-u8JPyX7Ha4kGoS8o",
       authDomain: "mountainmedicine-6e572.web.app",
@@ -100,6 +100,7 @@
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
     const provider = new GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
 
     function detectDevice() {
       return /iphone|ipad|android/i.test(navigator.userAgent) ? "mobile" : "desktop";
@@ -129,6 +130,7 @@
       localStorage.removeItem("mm_token_expiry");
       localStorage.removeItem("mm_token_handled");
       console.warn("Forced reauthentication triggered by app.");
+      await signOut(auth);
       signInWithRedirect(auth, provider);
     }
 


### PR DESCRIPTION
## Summary
- ensure logout clears tokens and redirects for re-auth
- avoid duplicate welcome toast
- fix login button markup and destination
- force account selection on login and sign out before redirect

## Testing
- `python -m py_compile app.py auth.py layout.py user_session_initializer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da2cdee088326b077cb2ba96cdc4f