### PR TITLE
Fix login redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,7 +144,19 @@ def handle_auth():
         st.session_state.clear()
         st.session_state.update(preserved)
         st.toast("You have been logged out")
-        st.switch_page("/login")
+        st.markdown(
+            """
+            <script>
+              localStorage.removeItem('mm_token');
+              localStorage.removeItem('mm_token_expiry');
+              localStorage.removeItem('mm_token_handled');
+              localStorage.removeItem('mm_device');
+              window.location.href='https://mountainmedicine-6e572.web.app/?forceLogin=true';
+            </script>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.stop()
 
     if "token" in query_params and "user" not in st.session_state:
         token = query_params.get("token")
@@ -159,7 +171,9 @@ def handle_auth():
 
         if user:
             st.session_state["user"] = user
-            st.toast(f"Welcome {user.get('name', 'back')} 👋")
+            if not st.session_state.get("__welcome_shown"):
+                st.toast(f"Welcome {user.get('name', 'back')} 👋")
+                st.session_state["__welcome_shown"] = True
             log_user_action(user.get("id", "unknown"), user.get("role", "viewer"), "login")
             st.query_params.clear()
         else:
@@ -169,7 +183,7 @@ def handle_auth():
             localStorage.removeItem('mm_token');
             localStorage.removeItem('mm_token_expiry');
             localStorage.removeItem('mm_token_handled');
-            window.location.href = "/";
+            window.location.href = "https://mountainmedicine-6e572.web.app/?forceLogin=true";
             </script>
             """, height=0)
             st.stop()
@@ -182,7 +196,7 @@ def handle_auth():
         if (token) {
           window.location.href = window.location.pathname + `?token=${token}&device=${device}`;
         } else {
-          window.location.href = "/login";
+          window.location.href = "https://mountainmedicine-6e572.web.app/?forceLogin=true";
         }
         </script>
         """, height=0)
@@ -252,8 +266,6 @@ def main():
     if user:
         st.session_state["user"] = user
         st.session_state["token_expiry"] = user.get("token_expiry")  # ✅ Add this line
-        st.toast(f"Welcome {user.get('name', 'back')} 👋")
-        log_user_action(user.get("id", "unknown"), user.get("role", "viewer"), "login")
         st.query_params.clear()
     if role != "admin":
         for admin_tab in ["Admin Panel"]:

--- a/layout.py
+++ b/layout.py
@@ -1105,14 +1105,12 @@ def render_login_status_button():
         name = user.get("name") or user.get("email")
         st.markdown(f"""
         <div style='position: fixed; top: 1rem; right: 1rem; z-index: 999;'>
-            <form action='/' method='post'>
-                <button onclick=\"window.location.href='/?logout=true'\">🔓 {name}</button>
-            </form>
+            <button onclick=\"window.location.href='/?logout=true'\">🔓 {name}</button>
         </div>
         """, unsafe_allow_html=True)
     else:
         st.markdown("""
         <div style='position: fixed; top: 1rem; right: 1rem; z-index: 999;'>
-            <button onclick=\"window.location.href='/login'\">🔐 Login</button>
+            <button onclick=\"window.location.href='https://mountainmedicine-6e572.web.app/?forceLogin=true'\">🔐 Login</button>
         </div>
         """, unsafe_allow_html=True)

--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
   </style>
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-app.js";
-    import { getAuth, GoogleAuthProvider, signInWithRedirect, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js";
+    import { getAuth, GoogleAuthProvider, signInWithRedirect, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.11.0/firebase-auth.js";
     const firebaseConfig = {
       apiKey: "AIzaSyBSpwzSf8hXxb4rBk-u8JPyX7Ha4kGoS8o",
       authDomain: "mountainmedicine-6e572.web.app",
@@ -100,6 +100,7 @@
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
     const provider = new GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
 
     function detectDevice() {
       return /iphone|ipad|android/i.test(navigator.userAgent) ? "mobile" : "desktop";
@@ -129,6 +130,7 @@
       localStorage.removeItem("mm_token_expiry");
       localStorage.removeItem("mm_token_handled");
       console.warn("Forced reauthentication triggered by app.");
+      await signOut(auth);
       signInWithRedirect(auth, provider);
     }
 


### PR DESCRIPTION
## Summary
- redirect missing token flow to hosted index.html
- ensure logout clears tokens and opens hosted login page
- force login button to use absolute URL

## Testing
- `python -m py_compile app.py auth.py layout.py user_session_initializer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685da2cdee088326b077cb2ba96cdc4f