### PR TITLE
Fix missing Upload UI imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from events import enhanced_event_ui, get_all_events
 from post_event import post_event_ui
 from file_storage import file_manager_ui, show_file_analytics
 from receipts import receipt_upload_ui
+from upload import upload_ui_desktop, upload_ui_mobile
 from pdf_export import pdf_export_ui
 from event_planning_dashboard import event_planning_dashboard_ui
 from event_modifications import event_modifications_ui


### PR DESCRIPTION
## Summary
- import `upload_ui_desktop` and `upload_ui_mobile` in `app.py`

## Testing
- `python -m py_compile upload.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685f1f6a329c83268ca6b9142fae15dd