### PR TITLE
Consolidate styling and unify navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ Instructions and structure overview.
 The app uses OpenAI to extract recipes, menus and other structured data.
 Responses are requested in JSON format using the API's `response_format` option
 to ensure valid output.
+
+## Styling and navigation
+
+All application styles live in `theme.css`. Mobile adjustments are wrapped in
+media queries like `@media (max-width: 768px)` so a single stylesheet serves
+both desktop and mobile users. The theme is injected once on startup via
+`apply_theme()`.
+
+Navigation is unified through the `render_top_navbar` component which is used on
+all devices. When running in mobile mode (`st.session_state["mobile_mode"]`
+set to `True`), `render_mobile_navigation` simply calls this same component so
+the experience remains consistent.

--- a/layout.py
+++ b/layout.py
@@ -13,7 +13,7 @@ from datetime import datetime
 def inject_custom_css():
     """Inject custom CSS styling for the application"""
     # Load the updated CSS file
-    css_path = Path(__file__).resolve().parent / "style.css"
+    css_path = Path(__file__).resolve().parent / "theme.css"
     try:
         with open(css_path, "r") as f:
             css_content = f.read()
@@ -801,43 +801,7 @@ def render_top_navbar(tabs):
             label_visibility="collapsed"
         )
 
-    # Stylize the nav bar
-    st.markdown(
-        """
-    <style>
-    .stRadio > div {
-        display: flex !important;
-        gap: 0 !important;
-        overflow: hidden !important;
-        background: var(--primary-purple, #6C4AB6) !important;
-        border-radius: var(--border-radius) !important;
-    }
-    .stRadio > div > label {
-        flex: 1 1 auto !important;
-        background: transparent !important;
-        color: #ffffff !important;
-        opacity: 0.85 !important;
-        border: none !important;
-        border-right: 1px solid rgba(255,255,255,0.4) !important;
-        border-radius: 0 !important;
-        padding: 0.5rem 1rem !important;
-        font-weight: 500 !important;
-        font-size: 0.9rem !important;
-        cursor: pointer !important;
-    }
-    .stRadio > div > label:last-child {
-        border-right: none !important;
-    }
-    .stRadio > div > label[aria-checked="true"] {
-        background: var(--accent-purple, #563a9d) !important;
-        color: #fff !important;
-        opacity: 1 !important;
-    }
-    .stRadio input[type="radio"] { display: none !important; }
-    </style>
-    """,
-        unsafe_allow_html=True,
-    )
+
 
     return selected
 
@@ -891,11 +855,6 @@ def apply_theme():
     from mobile_layout import mobile_layout
     if st.session_state.get("mobile_mode"):
         mobile_layout.apply_mobile_theme()
-        try:
-            from mobile_components import inject_mobile_styles
-            inject_mobile_styles()
-        except Exception:
-            pass
     render_event_mode_indicator()
     render_login_status_button()
 

--- a/mobile_components.py
+++ b/mobile_components.py
@@ -27,48 +27,6 @@ def render_mobile_header(title: str = "Mountain Medicine", show_menu: bool = Tru
     """
     st.markdown(header_html, unsafe_allow_html=True)
 
-def render_bottom_navigation(active_tab: str = "dashboard") -> str:
-    """Render mobile bottom navigation bar"""
-    nav_items = [
-        {"id": "dashboard", "icon": "🏠", "label": "Home", "path": "dashboard"},
-        {"id": "events", "icon": "📅", "label": "Events", "path": "events"},
-        {"id": "recipes", "icon": "📖", "label": "Recipes", "path": "recipes"},
-        {"id": "chat", "icon": "💬", "label": "Chat", "path": "assistant"},
-        {"id": "more", "icon": "⋯", "label": "More", "path": "more"}
-    ]
-    
-    nav_html = '<div class="bottom-nav">'
-    for item in nav_items:
-        active_class = "active" if item["id"] == active_tab else ""
-        nav_html += f"""
-        <div class="bottom-nav-item {active_class}" data-path="{item['path']}" onclick="navigateToTab('{item['path']}')">
-            <span class="bottom-nav-icon">{item['icon']}</span>
-            <span class="bottom-nav-label">{item['label']}</span>
-        </div>
-        """
-    nav_html += '</div>'
-    
-    st.markdown(nav_html, unsafe_allow_html=True)
-    
-    # JavaScript for navigation
-    nav_js = """
-    <script>
-    function navigateToTab(path) {
-        // Update Streamlit session state
-        window.parent.postMessage({
-            type: 'streamlit:setComponentValue',
-            key: 'mobile_nav',
-            value: path
-        }, '*');
-    }
-    </script>
-    """
-    st.markdown(nav_js, unsafe_allow_html=True)
-    
-    # Handle navigation in Python
-    if "mobile_nav" in st.session_state:
-        return st.session_state.mobile_nav
-    return active_tab
 
 # -----------------------------
 # Mobile Card Components
@@ -538,28 +496,6 @@ def mobile_search_bar(
 # Mobile Tab Component
 # -----------------------------
 
-def mobile_tabs(
-    tabs: List[str],
-    active_tab: int = 0,
-    key: str = "tabs"
-) -> int:
-    """Render mobile-optimized tabs"""
-    tabs_html = f'<div class="mobile-tabs" id="{key}">'
-    
-    for i, tab in enumerate(tabs):
-        active_class = "active" if i == active_tab else ""
-        tabs_html += f"""
-        <button class="mobile-tab {active_class}" 
-                onclick="selectTab('{key}', {i})">
-            {tab}
-        </button>
-        """
-    
-    tabs_html += '</div>'
-    
-    st.markdown(tabs_html, unsafe_allow_html=True)
-    
-    return st.session_state.get(f"{key}_selected", active_tab)
 
 # -----------------------------
 # Mobile Floating Action Button
@@ -702,7 +638,7 @@ from pathlib import Path
 
 def inject_mobile_styles() -> None:
     """Inject all mobile-specific CSS"""
-    css_path = Path(__file__).resolve().parent / "mobile_style.css"
+    css_path = Path(__file__).resolve().parent / "theme.css"
     try:
         with open(css_path, "r") as f:
             mobile_css = f.read()

--- a/mobile_layout.py
+++ b/mobile_layout.py
@@ -72,11 +72,11 @@ def mobile_card(title: str, content: str = "", icon: Optional[str] = None):
 # -----------------------------
 # 📋 Navigation Renderer
 # -----------------------------
-def render_mobile_navigation():
-    nav_items = ["Dashboard", "Events", "Recipes", "Chat", "Profile"]
-    selected = st.selectbox("📱 Mobile Nav", nav_items, key="mobile_nav")
-    st.session_state.mobile_tab = selected
-    return selected
+def render_mobile_navigation(tabs=None):
+    """Mobile navigation wrapper using the desktop navbar"""
+    from layout import render_top_navbar
+    nav_tabs = tabs or ["Dashboard", "Events", "Recipes", "Chat", "Profile"]
+    return render_top_navbar(nav_tabs)
 
 
 # -----------------------------
@@ -100,7 +100,7 @@ class MobileLayout:
     
     def apply_mobile_theme(self):
         """Apply mobile-specific CSS and optimizations"""
-        css_file = Path(__file__).resolve().parent / "mobile_style.css"
+        css_file = Path(__file__).resolve().parent / "theme.css"
         try:
             with open(css_file, "r") as f:
                 mobile_css = f.read()
@@ -128,7 +128,7 @@ class MobileLayout:
             st.markdown(mobile_css, unsafe_allow_html=True)
     
     def render_mobile_navigation(self):
-        """Wrapper around the existing render_mobile_navigation function"""
+        """Use the unified top navigation for mobile"""
         return render_mobile_navigation()
     
     def render_mobile_dashboard(self, user, event):

--- a/theme.css
+++ b/theme.css
@@ -92,6 +92,7 @@ button:active, .stButton > button:active {
     min-width: max-content !important;
 }
 
+
 .stRadio > div {
     display: flex !important;
     gap: 0 !important;
@@ -130,6 +131,15 @@ button:active, .stButton > button:active {
 }
 .stRadio > div > label[aria-checked="true"] * {
     color: #ffffff !important;
+}
+.stRadio input[type="radio"] {
+    display: none !important;
+}
+
+.stRadio ul {
+    list-style: none !important;
+    padding-left: 0 !important;
+    margin: 0 !important;
 }
 
 /* -----------------------------
@@ -228,6 +238,17 @@ button:active, .stButton > button:active {
     background: #edeafa !important;
 }
 
+/* Style for recipe version expanders */
+.version-expander {
+    margin-left: calc(var(--touch-target-size) / 2);
+    margin-bottom: 0;
+}
+
+.version-expander .streamlit-expanderHeader {
+    min-height: calc(var(--touch-target-size) / 2) !important;
+    font-size: 0.75rem;
+}
+
 /* -----------------------------
    MOBILE FORMS
 ----------------------------- */
@@ -258,6 +279,7 @@ button:active, .stButton > button:active {
 .stSelectbox div[data-baseweb="select"] input::placeholder {
     color: #6c757d !important;
 }
+
 
 /* Touch-friendly checkboxes */
 .stCheckbox label {
@@ -453,3 +475,44 @@ button:active, .stButton > button:active {
 .loading {
     animation: pulse 1.5s ease-in-out infinite !important;
 }
+
+/* -----------------------------
+   Tab Styling Overrides
+----------------------------- */
+.stTabs [data-baseweb="tab"] button {
+    background: var(--primary-purple) !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+    border-radius: var(--border-radius) var(--border-radius) 0 0 !important;
+    padding: 0.5rem 1rem !important;
+    margin-right: 0.25rem !important;
+}
+
+.stTabs [data-baseweb="tab"][aria-selected="true"] button {
+    background: var(--dark-purple) !important;
+    color: #fff !important;
+}
+
+.stTabs [data-baseweb="tab-highlight"] {
+    display: none !important;
+}
+
+/* Event list buttons */
+button[id^="upcoming_"], button[id^="view_"] {
+    font-size: 1.3rem !important;
+    color: #fff !important;
+    white-space: normal !important;
+    line-height: 1.2 !important;
+}
+
+/* Divider for delete column */
+.event-delete-col {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+    padding-left: 0.5rem;
+}
+
+/* Mobile-specific adjustments */
+@media (max-width: 768px) {
+    .nav-container { overflow-x: auto !important; }
+    .nav-tabs { flex-wrap: nowrap !important; }
+}
+


### PR DESCRIPTION
## Summary
- merge all CSS into new `theme.css`
- inject `theme.css` from layout helpers
- remove duplicate mobile nav components and reuse top navbar on mobile
- document styling and navigation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604a3925648326b235ce461424708f