### PR TITLE
Hide stRadio selection indicator

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -122,6 +122,9 @@ button:active, .stButton > button:active {
     list-style: none !important;
     outline: none !important;
 }
+.stRadio > div > label::before {
+    display: none !important;
+}
 .stRadio > div > label:focus {
     outline: none !important;
     box-shadow: none !important;


### PR DESCRIPTION
## Summary
- remove default radio circle for nav tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631d9bbe2483269ab720e1ed9b5e44