### PR TITLE
Fix tab text alignment and weight

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -101,7 +101,7 @@ button:active, .stButton > button:active {
     border-radius: var(--border-radius) !important;
 }
 
-.stRadio > div > label {
+.stRadio label {
     flex: 1 1 auto !important;
     background: transparent !important;
     color: #ffffff !important;
@@ -110,36 +110,48 @@ button:active, .stButton > button:active {
     border-right: 1px solid rgba(255, 255, 255, 0.4) !important;
     border-radius: 0 !important;
     padding: 0.75rem 1.25rem !important;
-    font-weight: 500 !important;
-    font-size: 1.1rem !important;
+    font-weight: 700 !important;
+    font-size: 1.375rem !important;
     cursor: pointer !important;
     transition: var(--transition) !important;
     min-height: var(--touch-target-size) !important;
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
+    text-align: center !important;
     white-space: nowrap !important;
     list-style: none !important;
     outline: none !important;
 }
-.stRadio > div > label::before,
-.stRadio > div > label::after,
-.stRadio > div > label > div:first-child {
+.stRadio label * {
+    color: inherit !important;
+    text-align: inherit !important;
+}
+.stRadio label > div {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 100% !important;
+}
+
+.stRadio label::before,
+.stRadio label::after,
+.stRadio label > div:first-child {
     display: none !important;
 }
-.stRadio > div > label:focus {
+.stRadio label:focus {
     outline: none !important;
     box-shadow: none !important;
 }
-.stRadio > div > label:last-child {
+.stRadio label:last-child {
     border-right: none !important;
 }
-.stRadio > div > label[aria-checked="true"] {
+.stRadio label[aria-checked="true"] {
     background: var(--accent-purple, #563a9d) !important;
     color: #ffffff !important;
     opacity: 1 !important;
 }
-.stRadio > div > label[aria-checked="true"] * {
+.stRadio label[aria-checked="true"] * {
     color: #ffffff !important;
 }
 .stRadio input[type="radio"] {


### PR DESCRIPTION
## Summary
- bold main radio tab labels
- ensure text centers in each tab with new flex wrapper

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6863274700c08326a3c6a63a05ab9c9a