### PR TITLE
Implement event headcount syncing for scaling

### DIFF
--- a/event_planning_dashboard.py
+++ b/event_planning_dashboard.py
@@ -3,6 +3,7 @@ from mobile_helpers import safe_columns, safe_file_uploader
 from firebase_init import db
 from utils import session_get, generate_id, format_date, delete_button
 from menu_viewer import menu_viewer_ui
+from event_file import update_event_file_field
 from file_storage import save_uploaded_file
 from datetime import datetime
 from layout import render_event_toolbar
@@ -198,6 +199,8 @@ def event_planning_dashboard_ui(event_id):
                 
                 if save_event_data(event_id, data):
                     st.success("✅ Event details updated successfully!")
+                    update_event_file_field(event_id, "guest_count", headcount, get_user_id(user))
+                    update_event_file_field(event_id, "staff_count", staff_count, get_user_id(user))
                     # Reset form state to show updated values
                     st.session_state[f"{form_key}_initialized"] = False
 

--- a/events.py
+++ b/events.py
@@ -161,13 +161,14 @@ def create_event(event_data: dict, user_id: str) -> str:
         db.collection("events").document(event_id).set(event_data)
 
          # ✅ Create canonical event_file under /events/{eventId}/meta/event_file
-        db.collection("events").document(event_id).collection("meta").document("event_file").set({
-            "menu": [],
-            "menu_html": "",
-            "schedule": [],
-            "equipment": [],
-            "notes": ""
+        from event_file import get_default_event_file
+        base_file = get_default_event_file()
+        base_file.update({
+            "guest_count": event_data.get("guest_count", 0),
+            "staff_count": event_data.get("staff_count", 0),
+            "event_id": event_id,
         })
+        db.collection("events").document(event_id).collection("meta").document("event_file").set(base_file)
 
         return event_id
         

--- a/smart_recipe_scaler.py
+++ b/smart_recipe_scaler.py
@@ -40,12 +40,18 @@ def scale_menu(event_file: dict, recipes: List[dict]) -> Dict[str, dict]:
     guest_count = event_file.get("guest_count", 0)
     staff_count = event_file.get("staff_count", 0)
     excluded_allergens = event_file.get("allergens", [])
+    event_id = event_file.get("event_id")
 
     total_people = guest_count + staff_count
     scaled_recipes = {}
 
     for recipe in recipes:
-        allergy_conflict = check_recipe_for_allergies(recipe, excluded_allergens)
+        allergy_conflict = 0
+        if event_id and recipe.get("id"):
+            conflicts = check_recipe_for_allergies(recipe["id"], event_id)
+            allergy_conflict = len(conflicts)
+        elif isinstance(excluded_allergens, list):
+            allergy_conflict = len(excluded_allergens)
         if allergy_conflict:
             adjusted_people = total_people - allergy_conflict
             allergy_warning = f"{allergy_conflict} people excluded due to allergen conflict"


### PR DESCRIPTION
## Summary
- include guest and staff counts in event_file
- sync headcount updates from planning dashboard
- store defaults when creating events
- fix smart scaler allergy checks using event_id

## Testing
- `python -m py_compile recipes_editor.py menu_viewer.py event_file.py events.py event_planning_dashboard.py smart_recipe_scaler.py`


------
https://chatgpt.com/codex/tasks/task_e_68634e954cbc832689c94931874e574f