### PR TITLE
Fix menu viewer scaling issues and allergies import

### DIFF
--- a/allergies.py
+++ b/allergies.py
@@ -1,6 +1,7 @@
 # allergies.py
 
 import streamlit as st
+from firebase_init import db
 from utils import generate_id, format_date, get_active_event_id, get_event_by_id, delete_button
 from auth import require_login, get_user_role
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix missing `db` import in `allergies.py`
- show recipe editor when auto-scaling fails due to missing `serves`
- remove unsupported `key` arg from Streamlit expanders

## Testing
- `python -m py_compile allergies.py menu_viewer.py recipes_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_6864b7d10c3c8326893c74c46b989972