### PR TITLE
Add slide-out mobile menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ media queries like `@media (max-width: 768px)` so a single stylesheet serves
 both desktop and mobile users. The theme is injected once on startup via
 `apply_theme()`.
 
-Navigation is unified through the `render_top_navbar` component which is used on
-all devices. When running in mobile mode (`st.session_state["mobile_mode"]`
-set to `True`), `render_mobile_navigation` simply calls this same component so
-the experience remains consistent.
+Navigation is unified through the `render_top_navbar` component on desktop.
+When mobile mode is enabled (`st.session_state["mobile_mode"]` set to `True`),
+`render_mobile_navigation` renders a slide-out menu triggered by the hamburger
+button in the mobile header.

--- a/mobile_components.py
+++ b/mobile_components.py
@@ -7,8 +7,22 @@ from datetime import datetime
 # Mobile Navigation Components
 # -----------------------------
 
-def render_mobile_header(title: str = "Mountain Medicine", show_menu: bool = True) -> None:
-    """Render mobile-optimized header with hamburger menu"""
+def render_mobile_header(
+    title: str = "Mountain Medicine",
+    show_menu: bool = True,
+    nav_items: Optional[List[str]] = None,
+) -> None:
+    """Render mobile header and hidden navigation menu"""
+    nav_items = nav_items or ["Dashboard", "Events", "Recipes", "Chat", "Profile"]
+
+    menu_html = "<div id=\"mobile-nav-menu\" class=\"mobile-nav-menu\">"
+    for item in nav_items:
+        menu_html += (
+            f"<a href=\"#\" class=\"mobile-nav-link\" "
+            f"onclick=\"selectMobileNav('{item}')\">{item}</a>"
+        )
+    menu_html += "</div>"
+
     header_html = f"""
     <div class="mobile-header">
         <div class="mobile-header-content">
@@ -24,6 +38,7 @@ def render_mobile_header(title: str = "Mountain Medicine", show_menu: bool = Tru
             </div>
         </div>
     </div>
+    {menu_html}
     """
     st.markdown(header_html, unsafe_allow_html=True)
 
@@ -660,9 +675,28 @@ def inject_mobile_scripts() -> None:
     try:
         with open("mobile_interactions.js", "r") as f:
             mobile_js = f.read()
-        st.markdown(f"<script>{mobile_js}</script>", unsafe_allow_html=True)
     except FileNotFoundError:
-        st.warning("Mobile JavaScript file not found.")
+        mobile_js = ""
+
+    mobile_js += """
+    function toggleMobileMenu() {
+        const menu = document.getElementById('mobile-nav-menu');
+        if (menu) {
+            menu.classList.toggle('show');
+        }
+    }
+
+    function selectMobileNav(tab) {
+        window.parent.postMessage({
+            type: 'streamlit:setComponentValue',
+            key: 'top_nav',
+            value: tab
+        }, '*');
+        toggleMobileMenu();
+    }
+    """
+
+    st.markdown(f"<script>{mobile_js}</script>", unsafe_allow_html=True)
 
 def detect_mobile() -> bool:
     """Detect if user is on mobile device"""

--- a/mobile_layout.py
+++ b/mobile_layout.py
@@ -73,9 +73,17 @@ def mobile_card(title: str, content: str = "", icon: Optional[str] = None):
 # 📋 Navigation Renderer
 # -----------------------------
 def render_mobile_navigation(tabs=None):
-    """Mobile navigation wrapper using the desktop navbar"""
-    from layout import render_top_navbar
+    """Render navigation; use dropdown menu on mobile"""
     nav_tabs = tabs or ["Dashboard", "Events", "Recipes", "Chat", "Profile"]
+
+    if st.session_state.get("mobile_mode"):
+        from mobile_components import render_mobile_header, inject_mobile_scripts
+
+        inject_mobile_scripts()
+        render_mobile_header(nav_items=nav_tabs)
+        return st.session_state.get("top_nav", nav_tabs[0])
+
+    from layout import render_top_navbar
     return render_top_navbar(nav_tabs)
 
 

--- a/theme.css
+++ b/theme.css
@@ -545,3 +545,27 @@ button[id^="upcoming_"], button[id^="view_"] {
     .nav-tabs { flex-wrap: nowrap !important; }
 }
 
+/* Mobile slide-down navigation menu */
+.mobile-nav-menu {
+    display: none;
+    position: absolute;
+    top: 56px;
+    left: 0;
+    right: 0;
+    background: var(--primary-purple);
+    padding: 1rem;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 1000;
+}
+
+.mobile-nav-menu a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 1.2rem;
+}
+
+.mobile-nav-menu.show {
+    display: flex;
+}
+


### PR DESCRIPTION
## Summary
- extend mobile header with hidden navigation links
- inject minimal JS handlers for menu toggling and navigation
- style mobile navigation menu in `theme.css`
- render this menu when in mobile mode
- update README with new description

## Testing
- `python3 -m py_compile mobile_components.py mobile_layout.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c2285264832688d9d797ad2b695d