### PR TITLE
Fix mobile upload camera input

### DIFF
--- a/mobile_helpers.py
+++ b/mobile_helpers.py
@@ -22,6 +22,6 @@ def safe_dataframe(data, use_container_width=True, **kwargs):
 def safe_file_uploader(label, **kwargs):
     """Wrapper that handles mobile file upload with camera"""
     if st.session_state.get("mobile_mode", False):
-        return mobile_layout.handle_mobile_file_upload()
+        return mobile_layout.handle_mobile_file_upload(label, **kwargs)
     else:
         return st.file_uploader(label, **kwargs)  # ✅ FIXED: Direct st.file_uploader call

--- a/mobile_layout.py
+++ b/mobile_layout.py
@@ -105,7 +105,7 @@ class MobileLayout:
             except:
                 self._is_mobile = False
         return self._is_mobile
-    
+
     def apply_mobile_theme(self):
         """Apply mobile-specific CSS and optimizations"""
         css_file = Path(__file__).resolve().parent / "theme.css"
@@ -134,6 +134,13 @@ class MobileLayout:
             </style>
             """
             st.markdown(mobile_css, unsafe_allow_html=True)
+
+    def handle_mobile_file_upload(self, label: str = "Upload or take a photo", type: Optional[List[str]] = None):
+        """Provide a mobile-friendly file uploader with camera support."""
+        uploaded = st.file_uploader(label, type=type)
+        if not uploaded:
+            uploaded = st.camera_input(label)
+        return uploaded
     
     def render_mobile_navigation(self):
         """Use the unified top navigation for mobile"""

--- a/recipes.py
+++ b/recipes.py
@@ -248,7 +248,7 @@ def add_recipe_via_link_ui():
             instructions = st.text_area("Instructions", value=instructions_value, key="link_instructions")
 
             parsed_image_url = data.get("image_url")
-            image_file = st.file_uploader(
+            image_file = safe_file_uploader(
                 "Recipe Photo",
                 type=["png", "jpg", "jpeg"],
                 key="link_image_upload",

--- a/upload.py
+++ b/upload.py
@@ -79,7 +79,10 @@ def upload_ui_mobile():
     db = get_db()
 
     st.markdown("### Upload a new file")
-    uploaded_file = st.file_uploader("Drop or select a file", type=["pdf", "txt", "jpg", "png", "jpeg", "csv", "docx"])
+    uploaded_file = safe_file_uploader(
+        "Drop or select a file",
+        type=["pdf", "txt", "jpg", "png", "jpeg", "csv", "docx"],
+    )
 
     if uploaded_file:
         with st.spinner("Parsing and uploading..."):


### PR DESCRIPTION
## Summary
- use `safe_file_uploader` when uploading files on mobile
- allow recipe photo upload from camera

## Testing
- `python -m py_compile mobile_layout.py mobile_helpers.py upload.py recipes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865eaa3118c83268e46495a55c4fbca