### PR TITLE
Fix number input type errors and remove increment buttons

### DIFF
--- a/admin_utilities.py
+++ b/admin_utilities.py
@@ -175,7 +175,7 @@ def _cleanup_tools():
     
     col1, col2 = st.columns(2)
     with col1:
-        days_old = st.number_input("Mark suggestions as stale after (days):", min_value=1, value=14)
+        days_old = st.number_input("Mark suggestions as stale after (days):", min_value=1, value=14, step=None)
     with col2:
         if st.button("🧹 Clean Stale Suggestions"):
             try:
@@ -364,7 +364,7 @@ def _archive_event_tool():
         
         with col2:
             # Option to archive events older than X days
-            days_old = st.number_input("Or archive events completed more than X days ago:", min_value=1, value=30)
+            days_old = st.number_input("Or archive events completed more than X days ago:", min_value=1, value=30, step=None)
             
             if st.button(f"📦 Archive Events Older Than {days_old} Days"):
                 cutoff_date = datetime.utcnow() - timedelta(days=days_old)

--- a/event_planning_dashboard.py
+++ b/event_planning_dashboard.py
@@ -135,8 +135,8 @@ def event_planning_dashboard_ui(event_id):
             if start > end:
                 st.error("⚠️ Start date must be before end date")
                 
-            headcount = st.number_input("👥 Expected Guests", min_value=0, value=event.get("guest_count", 0))
-            staff_count = st.number_input("🧑‍🍳 Staff Count", min_value=0, value=event.get("staff_count", 0))
+            headcount = st.number_input("👥 Expected Guests", min_value=0, value=event.get("guest_count", 0), step=None)
+            staff_count = st.number_input("🧑‍🍳 Staff Count", min_value=0, value=event.get("staff_count", 0), step=None)
 
         # Additional details - FIXED
         st.markdown("## 📝 Additional Information")
@@ -424,7 +424,7 @@ def _render_equipment_list_editor(event_id):
         with col1:
             equipment_name = st.text_input("Equipment Name *")
         with col2:
-            quantity = st.number_input("Quantity", min_value=1, value=1)
+            quantity = st.number_input("Quantity", min_value=1, value=1, step=None)
         
         category = st.selectbox("Category", ["Cooking", "Serving", "Storage", "Transport", "Safety", "Other"])
         

--- a/events.py
+++ b/events.py
@@ -259,7 +259,7 @@ def render_create_event_section(user: dict) -> None:
                     end_date = st.date_input("End Date *", format="MM/DD/YYYY")
             with col2:
                 description = st.text_area("Description", placeholder="Brief description of the event...")
-                guest_count = st.number_input("Expected Guests", min_value=0, value=20)
+                guest_count = st.number_input("Expected Guests", min_value=0, value=20, step=None)
 
             submitted = st.form_submit_button("Create Event", type="primary")
 

--- a/packing.py
+++ b/packing.py
@@ -206,7 +206,7 @@ def _render_equipment_list(event_id):
             with col1:
                 new_eq = st.text_input("Equipment Name")
             with col2:
-                quantity = st.number_input("Quantity", min_value=1, value=1)
+                quantity = st.number_input("Quantity", min_value=1, value=1, step=None)
             with col3:
                 category = st.selectbox("Category", ["Cooking", "Serving", "Storage", "Transport", "Safety", "Other"])
             

--- a/post_event.py
+++ b/post_event.py
@@ -174,7 +174,7 @@ def _render_post_event_form(event_id: str, event_data: dict, user: dict) -> None
                 "Total Event Cost ($)",
                 min_value=0.0,
                 value=float(existing_summary.get("total_cost", 0.0)),
-                step=10.0
+                step=None
             )
         with col2:
             cost_per_person = total_cost / event_data.get("guest_count", 1) if event_data.get("guest_count", 0) > 0 else 0

--- a/recipes.py
+++ b/recipes.py
@@ -369,7 +369,7 @@ def add_recipe_manual_ui():
         with st.form("manual_recipe_form"):
             name = st.text_input("Recipe Name", key="manual_recipe_name")
             special_version = st.text_input("Special Version", key="manual_special_version")
-            serves = st.number_input("Serves", min_value=1, value=4, key="manual_serves")
+            serves = st.number_input("Serves", min_value=1, value=4, key="manual_serves", step=None)
             ingredients = st.text_area("Ingredients", key="manual_ingredients")
             instructions = st.text_area("Instructions", key="manual_instructions")
             notes = st.text_area("Notes", key="manual_notes")
@@ -467,7 +467,7 @@ def add_recipe_via_upload_ui():
                     with col1:
                         st.text_input("Recipe Name", value=recipe_data.get("name", ""), disabled=True)
                         serves = recipe_data.get("serves") or recipe_data.get("servings", 4)
-                        st.number_input("Serves", value=float(serves), disabled=True)
+                        st.number_input("Serves", value=float(serves), disabled=True, step=None)
                     
                     with col2:
                         if recipe_data.get("image_url"):

--- a/recipes_editor.py
+++ b/recipes_editor.py
@@ -64,7 +64,7 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
             value=recipe.get("name") or recipe.get("title", ""),
         )
         special_version = st.text_input("Special Version", value=recipe.get("special_version", ""))
-        serves = st.number_input("Serves", min_value=0.5, step=0.5, value=float(recipe.get("serves", 4)))
+        serves = st.number_input("Serves", min_value=0.5, step=None, value=float(recipe.get("serves", 4)))
         
         ingredients = st.text_area("Ingredients", value=value_to_text(recipe.get("ingredients")))
         if prefill_data and recipe.get("ingredients"):
@@ -140,8 +140,8 @@ def recipe_editor_ui(recipe_id=None, prefill_data=None):
     # Scaling controls outside the main form
     target_servings = st.number_input(
         "Scale to how many servings?",
-        value=recipe.get("serves", 0),
-        step=0.5,
+        value=float(recipe.get("serves", 4)),
+        step=None,
     )
     if st.button("Scale Recipe"):
         try:


### PR DESCRIPTION
- Fix type mismatch error in recipes_editor.py by ensuring all number_input params are same type
- Remove plus/minus buttons from all number inputs by setting step=None
- Affects recipe serves, event guests, equipment quantities, and other numeric fields
- Provides cleaner UI especially for mobile users

🤖 Generated with [Claude Code](https://claude.ai/code)